### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ For clients that don't support streamable HTTP (e.g. Gemini CLI), use the SSE en
 }
 ```
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/gosodax-builders-sodax-mcp-server).
+
 ## Tools
 
 ### Network Configuration (8 tools)


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/gosodax-builders-sodax-mcp-server).