### PR TITLE
chore: make PORT env-driven for Coolify migration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,5 +5,5 @@ POSTHOG_SERVER_NAME=builders-mcp
 POSTHOG_DISTINCT_ID=sodax-builders-mcp
 
 # Server configuration
-# PORT=3000
+PORT=3000
 # TRANSPORT=http

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,9 +41,6 @@ RUN chown -R appuser:appgroup /app
 
 # Set environment
 ENV NODE_ENV=production
-ENV PORT=3001
-
-EXPOSE 3001
 
 USER appuser
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,17 @@
-version: '3.8'
-
 services:
-  marketing-sodax-mcp-server:
+  builders-sodax-mcp-server:
     build: .
-    container_name: marketing-sodax-mcp-server
+    container_name: builders-sodax-mcp-server
+    env_file: .env
     ports:
-      - "3000:3000"
+      - "${PORT}:${PORT}"
     environment:
       - NODE_ENV=production
-      - PORT=3000
+      - PORT=${PORT}
       - TRANSPORT=http
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost:3000/health"]
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:${PORT}/health"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## Summary
- Remove `ENV PORT=3001` and `EXPOSE 3001` from the Dockerfile so Coolify's own port config no longer conflicts with a value baked into the image
- Wire `docker-compose.yml` to read `${PORT}` from `.env` in `ports`, `environment`, and the healthcheck; add explicit `env_file: .env`
- Rename the compose service + `container_name` from `marketing-sodax-mcp-server` to `builders-sodax-mcp-server` and drop the obsolete top-level `version: '3.8'` key
- Uncomment `PORT=3000` in `.env.example` so it's treated as required when running via compose

Related to #3 (do not close on merge — this is one of several sub-tasks on that issue).

## Test plan
- [x] `docker compose config` resolves `${PORT}` correctly at both `3000` and `3005`
- [x] `docker compose up --build` boots the container; logs show `running on http://0.0.0.0:3000`, GitBook proxy init succeeds, API drift check passes
- [x] `GET /health` and `GET /api` both return 200
- [x] `docker compose down` tears down cleanly
- [x] Reviewer to sanity-check that Coolify auto-deploy still succeeds once this merges into `development`

🤖 Generated with [Claude Code](https://claude.com/claude-code)