### PR TITLE
chore: use curl-based Docker healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,9 @@ FROM node:20-alpine
 
 WORKDIR /app
 
-# Install pnpm
-RUN corepack enable && corepack prepare pnpm@9.15.0 --activate
+# Install pnpm and curl (curl is used by the Docker healthcheck)
+RUN apk add --no-cache curl && \
+    corepack enable && corepack prepare pnpm@9.15.0 --activate
 
 # Copy package files
 COPY package.json pnpm-lock.yaml* ./

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,8 @@ services:
       - TRANSPORT=http
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost:${PORT}/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:${PORT}/health"]
       interval: 30s
       timeout: 10s
-      retries: 3
-      start_period: 10s
+      retries: 10
+      start_period: 40s


### PR DESCRIPTION
## Problem

After the first Coolify-migration PR merged, the container on `clf.sodax.com` deployed but was reported as `(unhealthy)` in both `docker ps` and the Coolify UI. The app itself was fine — `curl -f http://localhost:3008/health` from the host returned the expected 200 JSON payload. The failure was in the healthcheck command, not the service.

**Root cause:** `wget -q --spider` in `node:20-alpine` uses busybox wget, which is flaky against node's default chunked-transfer-encoded HTTP responses — it can exit non-zero even when the endpoint is reachable.

## Fix

- **`Dockerfile`** — install `curl` in the runtime stage (`apk add --no-cache curl`), since `node:20-alpine` doesn't ship with it.
- **`docker-compose.yml`** — healthcheck switched from `wget --spider` to `curl -f`. Also bumped `retries` 3 → 10 and `start_period` 10s → 40s to match a known-working reference pattern from another project.

Related to #3 (do not close on merge — sub-task of the broader migration).

## Test plan

- [x] `docker compose up --build -d` with a seeded `.env` — container starts cleanly
- [x] `docker inspect` transitions from `starting` → `healthy` after the start period; health log shows `curl` returning the `/health` JSON with HTTP 200
- [x] `docker compose down` tears down cleanly
- [ ] Reviewer to confirm Coolify reports the deployment as healthy after the rebuild on `development`

🤖 Generated with [Claude Code](https://claude.com/claude-code)