### PR TITLE
docs: document staging and production environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,22 @@ pnpm start
 
 ## Deployment
 
+### Environments
+
+The server runs in two Coolify environments on the tech-team infrastructure (`clf.sodax.com`):
+
+| Environment | URL | Tracks branch |
+|-------------|-----|---------------|
+| Production | https://builders.sodax.com | `master` |
+| Staging | https://test-builders-mcp.coolify.iconblockchain.xyz | `development` |
+
+Promotion flow:
+
+1. Feature branches → PR into `development` → auto-deploys to **staging** on merge.
+2. `development` → PR into `master` → auto-deploys to **production** on merge.
+
+Hotfixes can branch off `master` and PR directly into `master`, then be merged back into `development`.
+
 ### Docker
 
 ```bash


### PR DESCRIPTION
## Summary

Add an **Environments** subsection under `Deployment` in the README to document the two Coolify apps on `clf.sodax.com`:

| Environment | URL | Tracks branch |
|---|---|---|
| Production | https://builders.sodax.com | `master` |
| Staging | https://test-builders-mcp.coolify.iconblockchain.xyz | `development` |

Also documents the PR-driven promotion flow (feature → `development` → staging, `development` → `master` → prod, hotfixes direct to `master` then merged back).

Related to #7 (do not close on merge — the staging/prod env setup itself is tracked there).

## Test plan

- [x] README renders correctly on GitHub preview
- [ ] Reviewer to confirm the branch/URL mapping matches the actual Coolify config

🤖 Generated with [Claude Code](https://claude.com/claude-code)