### PR TITLE
fix(tools): reconcile 16 drifts from check:drift

### DIFF
--- a/src/services/apiDriftCheck.ts
+++ b/src/services/apiDriftCheck.ts
@@ -79,7 +79,7 @@ const TOOL_CONTRACT: Record<EndpointKey, ToolContract> = {
   },
   "GET /config/hub/assets": {
     tool: "sodax_get_hub_assets",
-    params: [],
+    params: ["chainId"],
     requiredParams: [],
     allowToolExtra: ["chainId"],
   },
@@ -90,7 +90,7 @@ const TOOL_CONTRACT: Record<EndpointKey, ToolContract> = {
   },
   "GET /config/swap/tokens": {
     tool: "sodax_get_swap_tokens",
-    params: [],
+    params: ["chainId"],
     requiredParams: [],
     allowToolExtra: ["chainId"],
   },
@@ -102,7 +102,7 @@ const TOOL_CONTRACT: Record<EndpointKey, ToolContract> = {
   },
   "GET /config/money-market/tokens": {
     tool: "sodax_get_money_market_tokens",
-    params: [],
+    params: ["chainId"],
     requiredParams: [],
     allowToolExtra: ["chainId"],
   },

--- a/src/services/apiDriftCheck.ts
+++ b/src/services/apiDriftCheck.ts
@@ -28,6 +28,13 @@ interface ToolContract {
   /** Subset of `params` the tool marks non-optional. */
   requiredParams: string[];
   /**
+   * Params the tool accepts that are NOT query/path params on THIS endpoint —
+   * used when a single tool wraps multiple endpoint variants and the extra
+   * param is a routing switch between them. Suppresses the "tool declares
+   * param X not in spec" warning for the listed names on this endpoint only.
+   */
+  allowToolExtra?: string[];
+  /**
    * Expected top-level property names in the 200 response schema.
    * Omit when the endpoint returns a primitive, a dynamic map, or when the
    * spec provides no object schema — those are reported as "uncovered".
@@ -72,8 +79,9 @@ const TOOL_CONTRACT: Record<EndpointKey, ToolContract> = {
   },
   "GET /config/hub/assets": {
     tool: "sodax_get_hub_assets",
-    params: ["chainId"],
+    params: [],
     requiredParams: [],
+    allowToolExtra: ["chainId"],
   },
   "GET /config/hub/:chainId/assets": {
     tool: "sodax_get_hub_assets",
@@ -82,8 +90,9 @@ const TOOL_CONTRACT: Record<EndpointKey, ToolContract> = {
   },
   "GET /config/swap/tokens": {
     tool: "sodax_get_swap_tokens",
-    params: ["chainId"],
+    params: [],
     requiredParams: [],
+    allowToolExtra: ["chainId"],
   },
   "GET /config/swap/:chainId/tokens": {
     tool: "sodax_get_swap_tokens",
@@ -93,8 +102,9 @@ const TOOL_CONTRACT: Record<EndpointKey, ToolContract> = {
   },
   "GET /config/money-market/tokens": {
     tool: "sodax_get_money_market_tokens",
-    params: ["chainId"],
+    params: [],
     requiredParams: [],
+    allowToolExtra: ["chainId"],
   },
   "GET /config/money-market/reserve-assets": {
     tool: "sodax_get_money_market_reserve_assets",
@@ -116,7 +126,7 @@ const TOOL_CONTRACT: Record<EndpointKey, ToolContract> = {
   "GET /amm/pools/:chainId/:poolId/candles": {
     tool: "sodax_get_amm_pool_candles",
     params: ["chainId", "poolId", "interval", "from", "to"],
-    requiredParams: ["chainId", "poolId"],
+    requiredParams: ["chainId", "poolId", "interval", "from", "to"],
     responseFields: ["poolId", "chainId", "interval", "from", "to", "candles"],
   },
   "GET /intent/tx/:txHash": {
@@ -127,7 +137,7 @@ const TOOL_CONTRACT: Record<EndpointKey, ToolContract> = {
   },
   "GET /intent/user/:userAddress": {
     tool: "sodax_get_user_transactions",
-    params: ["userAddress", "limit", "offset"],
+    params: ["userAddress", "limit", "offset", "startDate", "endDate", "fromTs", "toTs"],
     requiredParams: ["userAddress"],
     responseFields: ["items", "total", "offset", "limit"],
   },
@@ -139,13 +149,13 @@ const TOOL_CONTRACT: Record<EndpointKey, ToolContract> = {
   },
   "GET /solver/orderbook": {
     tool: "sodax_get_orderbook",
-    params: ["limit"],
-    requiredParams: [],
+    params: ["limit", "offset"],
+    requiredParams: ["limit", "offset"],
     responseFields: ["total", "data"],
   },
   "GET /solver/volume": {
     tool: "sodax_get_volume",
-    params: ["inputToken", "outputToken", "chainId", "solver", "fromBlock", "toBlock", "since", "until", "sort", "limit", "includeData", "cursor"],
+    params: ["inputToken", "outputToken", "chainId", "solver", "fromBlock", "toBlock", "since", "until", "fromTs", "toTs", "sort", "limit", "includeData", "cursor"],
     requiredParams: [],
     responseFields: ["items", "nextCursor", "hasMore"],
   },
@@ -156,7 +166,7 @@ const TOOL_CONTRACT: Record<EndpointKey, ToolContract> = {
   },
   "GET /moneymarket/position/:userAddress": {
     tool: "sodax_get_user_position",
-    params: ["userAddress", "chainId"],
+    params: ["userAddress"],
     requiredParams: ["userAddress"],
     responseFields: ["userAddress", "positions"],
   },
@@ -192,7 +202,7 @@ const TOOL_CONTRACT: Record<EndpointKey, ToolContract> = {
   },
   "GET /partners": {
     tool: "sodax_get_partners",
-    params: [],
+    params: ["chainId"],
     requiredParams: [],
     responseFields: ["partners"],
   },
@@ -402,7 +412,9 @@ export async function checkApiDrift(): Promise<DriftReport> {
         detail: `spec has param "${name}" not in tool "${contract.tool}"`,
       });
     }
+    const allowExtra = new Set(contract.allowToolExtra ?? []);
     for (const name of paramDiff.extra) {
+      if (allowExtra.has(name)) continue;
       paramIssues.push({
         endpoint: key,
         kind: "param-extra",

--- a/src/services/sodaxApi.ts
+++ b/src/services/sodaxApi.ts
@@ -138,8 +138,8 @@ export async function getUserTransactions(
 ): Promise<Transaction[]> {
   try {
     const params = new URLSearchParams();
-    if (options?.limit) params.append("limit", options.limit.toString());
-    if (options?.offset) params.append("offset", options.offset.toString());
+    if (options?.limit !== undefined) params.append("limit", options.limit.toString());
+    if (options?.offset !== undefined) params.append("offset", options.offset.toString());
     if (options?.startDate) params.append("startDate", options.startDate);
     if (options?.endDate) params.append("endDate", options.endDate);
     if (options?.fromTs !== undefined) params.append("fromTs", options.fromTs.toString());
@@ -217,12 +217,12 @@ export async function getVolume(options: {
  */
 export async function getOrderbook(options: {
   limit: number;
-  offset?: number;
+  offset: number;
 }): Promise<OrderbookEntry[]> {
   try {
     const params = new URLSearchParams();
     params.append("limit", options.limit.toString());
-    if (options.offset !== undefined) params.append("offset", options.offset.toString());
+    params.append("offset", options.offset.toString());
 
     const queryString = params.toString();
     const url = `/solver/orderbook${queryString ? `?${queryString}` : ""}`;

--- a/src/services/sodaxApi.ts
+++ b/src/services/sodaxApi.ts
@@ -127,12 +127,23 @@ export async function getTransaction(txHash: string): Promise<Transaction | null
  */
 export async function getUserTransactions(
   userAddress: string,
-  options?: { chainId?: string; limit?: number; offset?: number }
+  options?: {
+    limit?: number;
+    offset?: number;
+    startDate?: string;
+    endDate?: string;
+    fromTs?: number;
+    toTs?: number;
+  }
 ): Promise<Transaction[]> {
   try {
     const params = new URLSearchParams();
     if (options?.limit) params.append("limit", options.limit.toString());
     if (options?.offset) params.append("offset", options.offset.toString());
+    if (options?.startDate) params.append("startDate", options.startDate);
+    if (options?.endDate) params.append("endDate", options.endDate);
+    if (options?.fromTs !== undefined) params.append("fromTs", options.fromTs.toString());
+    if (options?.toTs !== undefined) params.append("toTs", options.toTs.toString());
 
     const queryString = params.toString();
     const url = `/intent/user/${userAddress}${queryString ? `?${queryString}` : ""}`;
@@ -160,6 +171,8 @@ export async function getVolume(options: {
   toBlock?: number;
   since?: string;
   until?: string;
+  fromTs?: number;
+  toTs?: number;
   sort?: "asc" | "desc";
   limit?: number;
   includeData?: boolean;
@@ -181,6 +194,8 @@ export async function getVolume(options: {
     if (options.toBlock) params.append("toBlock", options.toBlock.toString());
     if (options.since) params.append("since", options.since);
     if (options.until) params.append("until", options.until);
+    if (options.fromTs !== undefined) params.append("fromTs", options.fromTs.toString());
+    if (options.toTs !== undefined) params.append("toTs", options.toTs.toString());
     if (options.sort) params.append("sort", options.sort);
     if (options.limit) params.append("limit", options.limit.toString());
     if (options.cursor) params.append("cursor", options.cursor);
@@ -200,12 +215,14 @@ export async function getVolume(options: {
 /**
  * Get current orderbook entries from solver
  */
-export async function getOrderbook(options?: {
-  limit?: number;
+export async function getOrderbook(options: {
+  limit: number;
+  offset?: number;
 }): Promise<OrderbookEntry[]> {
   try {
     const params = new URLSearchParams();
-    if (options?.limit) params.append("limit", options.limit.toString());
+    params.append("limit", options.limit.toString());
+    if (options.offset !== undefined) params.append("offset", options.offset.toString());
 
     const queryString = params.toString();
     const url = `/solver/orderbook${queryString ? `?${queryString}` : ""}`;
@@ -243,8 +260,7 @@ export async function getMoneyMarketAssets(chainId?: string): Promise<MoneyMarke
  * Get user's money market position
  */
 export async function getUserPosition(
-  userAddress: string,
-  chainId?: string
+  userAddress: string
 ): Promise<UserPosition | null> {
   try {
     const response = await apiClient.get(`/moneymarket/position/${userAddress}`);
@@ -261,14 +277,18 @@ export async function getUserPosition(
 /**
  * List SODAX integration partners
  */
-export async function getPartners(): Promise<Partner[]> {
-  const cacheKey = "partners";
+export async function getPartners(chainId?: number): Promise<Partner[]> {
+  const cacheKey = `partners-${chainId ?? "all"}`;
   const cached = getCached<Partner[]>(cacheKey);
   if (cached) return cached;
 
   try {
-    const response = await apiClient.get("/partners");
-    const partners = response.data?.data || response.data || [];
+    const params = new URLSearchParams();
+    if (chainId !== undefined) params.append("chainId", chainId.toString());
+    const queryString = params.toString();
+    const url = `/partners${queryString ? `?${queryString}` : ""}`;
+    const response = await apiClient.get(url);
+    const partners = response.data?.data || response.data?.partners || response.data || [];
     setCache(cacheKey, partners);
     return partners;
   } catch (error) {

--- a/src/tools/sodaxApi.ts
+++ b/src/tools/sodaxApi.ts
@@ -209,13 +209,21 @@ export function registerSodaxApiTools(server: McpServer): void {
         .describe("Maximum number of transactions to return (1-100)"),
       offset: z.number().min(0).optional().default(0)
         .describe("Number of transactions to skip for pagination"),
+      startDate: z.string().optional()
+        .describe("Start date filter (ISO 8601, e.g. '2026-01-01'). Don't mix with fromTs/toTs."),
+      endDate: z.string().optional()
+        .describe("End date filter (ISO 8601). Don't mix with fromTs/toTs."),
+      fromTs: z.number().optional()
+        .describe("Start timestamp filter (unix seconds). Don't mix with startDate/endDate."),
+      toTs: z.number().optional()
+        .describe("End timestamp filter (unix seconds). Don't mix with startDate/endDate."),
       format: z.nativeEnum(ResponseFormat).optional().default(ResponseFormat.MARKDOWN)
         .describe("Response format: 'json' for raw data or 'markdown' for formatted text")
     },
     READ_ONLY,
-    async ({ userAddress, limit, offset, format }) => {
+    async ({ userAddress, limit, offset, startDate, endDate, fromTs, toTs, format }) => {
       try {
-        const transactions = await getUserTransactions(userAddress, { limit, offset });
+        const transactions = await getUserTransactions(userAddress, { limit, offset, startDate, endDate, fromTs, toTs });
         const header = `## Transactions for ${userAddress.slice(0, 10)}...${userAddress.slice(-8)}\n\n`;
         const summary = `${transactions.length} transactions found\n\n`;
         return {
@@ -251,9 +259,13 @@ export function registerSodaxApiTools(server: McpServer): void {
       toBlock: z.number().optional()
         .describe("End block number (don't mix with since/until)"),
       since: z.string().optional()
-        .describe("Start time ISO format (don't mix with fromBlock/toBlock)"),
+        .describe("Start time ISO format (don't mix with fromBlock/toBlock or fromTs/toTs)"),
       until: z.string().optional()
-        .describe("End time ISO format (don't mix with fromBlock/toBlock)"),
+        .describe("End time ISO format (don't mix with fromBlock/toBlock or fromTs/toTs)"),
+      fromTs: z.number().optional()
+        .describe("Start timestamp (unix seconds). Don't mix with since/until or fromBlock/toBlock."),
+      toTs: z.number().optional()
+        .describe("End timestamp (unix seconds). Don't mix with since/until or fromBlock/toBlock."),
       sort: z.enum(["asc", "desc"]).optional().default("desc")
         .describe("Sort order by block number"),
       limit: z.number().min(1).max(100).optional().default(50)
@@ -266,12 +278,12 @@ export function registerSodaxApiTools(server: McpServer): void {
         .describe("Response format: 'json' for raw data or 'markdown' for formatted text")
     },
     READ_ONLY,
-    async ({ inputToken, outputToken, chainId, solver, fromBlock, toBlock, since, until, sort, limit, includeData, cursor, format }) => {
+    async ({ inputToken, outputToken, chainId, solver, fromBlock, toBlock, since, until, fromTs, toTs, sort, limit, includeData, cursor, format }) => {
       try {
-        const volume = await getVolume({ 
-          chainId, inputToken, outputToken, solver, 
-          fromBlock, toBlock, since, until, 
-          sort, limit, includeData, cursor 
+        const volume = await getVolume({
+          chainId, inputToken, outputToken, solver,
+          fromBlock, toBlock, since, until, fromTs, toTs,
+          sort, limit, includeData, cursor
         });
         const header = `## SODAX Filled Intents\n\n`;
         const pagination = volume.hasMore && volume.nextCursor 
@@ -297,15 +309,17 @@ export function registerSodaxApiTools(server: McpServer): void {
     "sodax_get_orderbook",
     "Get current orderbook entries showing pending/open intents",
     {
-      limit: z.number().min(1).max(100).optional().default(20)
-        .describe("Maximum number of orders to return (1-100)"),
+      limit: z.number().min(1).max(100)
+        .describe("REQUIRED: Maximum number of orders to return (1-100)"),
+      offset: z.number().min(0)
+        .describe("REQUIRED: Number of orders to skip for pagination"),
       format: z.nativeEnum(ResponseFormat).optional().default(ResponseFormat.MARKDOWN)
         .describe("Response format: 'json' for raw data or 'markdown' for formatted text")
     },
     READ_ONLY,
-    async ({ limit, format }) => {
+    async ({ limit, offset, format }) => {
       try {
-        const orderbook = await getOrderbook({ limit });
+        const orderbook = await getOrderbook({ limit, offset });
         return {
           content: [{
             type: "text",
@@ -360,15 +374,13 @@ export function registerSodaxApiTools(server: McpServer): void {
     {
       userAddress: z.string()
         .describe("The wallet address to look up"),
-      chainId: z.string().optional()
-        .describe("Filter by chain ID"),
       format: z.nativeEnum(ResponseFormat).optional().default(ResponseFormat.MARKDOWN)
         .describe("Response format: 'json' for raw data or 'markdown' for formatted text")
     },
     READ_ONLY,
-    async ({ userAddress, chainId, format }) => {
+    async ({ userAddress, format }) => {
       try {
-        const position = await getUserPosition(userAddress, chainId);
+        const position = await getUserPosition(userAddress);
         if (!position) {
           return {
             content: [{ type: "text", text: `No money market position found for ${userAddress}` }]
@@ -394,13 +406,15 @@ export function registerSodaxApiTools(server: McpServer): void {
     "sodax_get_partners",
     "List all SODAX integration partners including wallets, DEXs, and other protocols",
     {
+      chainId: z.number().optional()
+        .describe("Filter partners by numeric chain ID (e.g. 146 for Sonic)"),
       format: z.nativeEnum(ResponseFormat).optional().default(ResponseFormat.MARKDOWN)
         .describe("Response format: 'json' for raw data or 'markdown' for formatted text")
     },
     READ_ONLY,
-    async ({ format }) => {
+    async ({ chainId, format }) => {
       try {
-        const partners = await getPartners();
+        const partners = await getPartners(chainId);
         return {
           content: [{
             type: "text",
@@ -660,12 +674,12 @@ export function registerSodaxApiTools(server: McpServer): void {
         .describe("Chain ID where the pool is deployed (e.g., 'sonic')"),
       poolId: z.string()
         .describe("The pool contract address or ID"),
-      interval: z.string().optional()
-        .describe("Candle interval (e.g., '1h', '4h', '1d')"),
-      from: z.number().optional()
-        .describe("Start timestamp (unix seconds)"),
-      to: z.number().optional()
-        .describe("End timestamp (unix seconds)"),
+      interval: z.enum(["1m", "5m", "15m", "1h", "4h", "1d"])
+        .describe("REQUIRED: Candle interval"),
+      from: z.number()
+        .describe("REQUIRED: Start timestamp (unix seconds)"),
+      to: z.number()
+        .describe("REQUIRED: End timestamp (unix seconds)"),
       format: z.nativeEnum(ResponseFormat).optional().default(ResponseFormat.MARKDOWN)
         .describe("Response format: 'json' for raw data or 'markdown' for formatted text")
     },

--- a/src/tools/sodaxApi.ts
+++ b/src/tools/sodaxApi.ts
@@ -406,7 +406,7 @@ export function registerSodaxApiTools(server: McpServer): void {
     "sodax_get_partners",
     "List all SODAX integration partners including wallets, DEXs, and other protocols",
     {
-      chainId: z.number().optional()
+      chainId: z.number().int().optional()
         .describe("Filter partners by numeric chain ID (e.g. 146 for Sonic)"),
       format: z.nativeEnum(ResponseFormat).optional().default(ResponseFormat.MARKDOWN)
         .describe("Response format: 'json' for raw data or 'markdown' for formatted text")


### PR DESCRIPTION
## Summary

Brings the MCP tool layer back in sync with the live SODAX OpenAPI spec. `pnpm check:drift` now exits 0.

### Track A — add 8 missing query params

| Tool | New params |
|---|---|
| `sodax_get_orderbook` | `offset` (spec-required) |
| `sodax_get_user_transactions` | `startDate`, `endDate`, `fromTs`, `toTs` |
| `sodax_get_volume` | `fromTs`, `toTs` |
| `sodax_get_partners` | `chainId` (numeric) |

### Track B — tighten required flags to match spec

- `sodax_get_amm_pool_candles`: `interval`, `from`, `to` no longer `.optional()`
- `sodax_get_orderbook`: `limit` no longer `.optional()`

### Track C — architectural cleanup

- **`allowToolExtra` contract field.** Adds `allowToolExtra?: string[]` to `ToolContract` so the drift check can suppress "tool-extra" warnings on base-endpoint variants whose tool routes to a sibling `/:chainId/...` variant. Applied to `/config/hub/assets`, `/config/swap/tokens`, `/config/money-market/tokens`. Keeps the existing 3 routing-wrapper tools exactly as-is; makes the routing intent explicit in the contract.
- **Remove dead `chainId`** from `sodax_get_user_position`. Upstream never accepted it; the service function was already ignoring it. No behavioral change for callers that were passing it — it's now rejected by Zod instead of silently discarded.
- **Fix `sodax_get_partners.chainId` type.** Spec declares it numeric; initial attempt with `z.string()` returned a 400 from upstream on the spot-check (`chainId must be an integer number`). Corrected to `z.number()` and verified end-to-end.

## Verification

- [x] `pnpm build` clean
- [x] `pnpm check:drift` exits 0 with:
      `✅ API drift check passed: 30 endpoints covered, params/required/response-fields all in sync (12 endpoints skip field check)`
- [x] End-to-end: `sodax_get_orderbook { limit: 3, offset: 0 }` returns 3 orderbook entries from upstream
- [x] End-to-end: `sodax_get_partners { chainId: 146 }` returns 19 partners
- [x] Rejection: `sodax_get_amm_pool_candles` without `interval`/`from`/`to` fails Zod validation at the MCP layer (doesn't 400 from upstream)

## Files changed

- `src/tools/sodaxApi.ts` — Zod schemas for 6 tools
- `src/services/sodaxApi.ts` — service function signatures + URLSearchParams builders
- `src/services/apiDriftCheck.ts` — `allowToolExtra` field + updated contract entries

Closes #11
Related: https://github.com/icon-project/ICON-Projects-Planning/issues/647

🤖 Generated with [Claude Code](https://claude.com/claude-code)