### PR TITLE
ci: use GitHub App token for release and sync workflows

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,8 +17,16 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      - name: Mint GitHub App installation token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+
       - uses: googleapis/release-please-action@v4
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           target-branch: master
+          token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,8 +6,7 @@ on:
       - master
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 concurrency:
   group: release-please

--- a/.github/workflows/sync-to-development.yml
+++ b/.github/workflows/sync-to-development.yml
@@ -18,6 +18,13 @@ jobs:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'chore: sync master to development')"
     steps:
+      - name: Mint GitHub App installation token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+
       - name: Checkout master with full history
         uses: actions/checkout@v4
         with:
@@ -26,8 +33,8 @@ jobs:
 
       - name: Configure git identity
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "${{ steps.app-token.outputs.app-slug }}[bot]"
+          git config user.email "${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
 
       - name: Fetch development
         run: git fetch origin development:development
@@ -47,23 +54,23 @@ jobs:
       - name: Fast-forward development to master
         if: steps.sync.outputs.ff == 'true'
         env:
-          SYNC_TOKEN: ${{ secrets.SYNC_TOKEN }}
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
           git checkout development
           git merge --ff-only master
-          git push "https://x-access-token:${SYNC_TOKEN}@github.com/${{ github.repository }}.git" development
+          git push "https://x-access-token:${APP_TOKEN}@github.com/${{ github.repository }}.git" development
 
       - name: Open sync PR on divergence
         if: steps.sync.outputs.ff == 'false'
         env:
-          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
-          SYNC_TOKEN: ${{ secrets.SYNC_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
           BRANCH="chore/sync-master-to-development-${{ github.run_id }}"
           git checkout -b "$BRANCH" master
-          git push "https://x-access-token:${SYNC_TOKEN}@github.com/${{ github.repository }}.git" "$BRANCH"
+          git push "https://x-access-token:${APP_TOKEN}@github.com/${{ github.repository }}.git" "$BRANCH"
           gh pr create \
             --repo "${{ github.repository }}" \
             --base development \

--- a/.github/workflows/sync-to-development.yml
+++ b/.github/workflows/sync-to-development.yml
@@ -6,8 +6,7 @@ on:
       - master
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 concurrency:
   group: sync-to-development

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,22 @@ Hotfixes follow the same path as any other change: branch off `development`, PR 
 
 ## Required secrets (admin setup)
 
-- `SYNC_TOKEN` — fine-grained PAT with **`contents: write`** AND **`pull requests: write`** on this repo. Used by the `sync-to-development` workflow to (a) fast-forward push to the protected `development` branch and (b) open a fallback sync PR via `gh pr create` if `development` has diverged from `master`. Upgrade to a GitHub App token later if desired.
+The release workflows authenticate as a **GitHub App** rather than a personal access token, so the automation does not depend on any individual user's account or PAT lifetime.
+
+- `RELEASE_BOT_APP_ID` — numeric App ID, found at the top of the App's settings page (`https://github.com/organizations/gosodax/settings/apps/<app-name>`).
+- `RELEASE_BOT_PRIVATE_KEY` — entire contents of a `.pem` file generated under "Private keys" on the App's settings page (including the `-----BEGIN/END PRIVATE KEY-----` lines).
+
+The App must be:
+- **Owned by the `gosodax` org.**
+- **Installed on this repository** (`gosodax/builders-sodax-mcp-server`).
+- Granted these repository permissions:
+  - `Contents`: Read and write
+  - `Pull requests`: Read and write
+  - `Metadata`: Read
+
+At workflow runtime, [`actions/create-github-app-token@v1`](https://github.com/actions/create-github-app-token) mints a short-lived (~1h) installation token from these two secrets. The token is used for FF pushes to `development`, opening fallback sync PRs, and as the token release-please uses to open release PRs (so downstream CI fires on those PRs once CI exists).
+
+To rotate the App's private key: regenerate it in the App's settings and update the `RELEASE_BOT_PRIVATE_KEY` repo secret. To replace the App entirely: install the new App, swap both secrets, update the bypass actor on the `development` ruleset.
 
 ## Required branch protection (admin setup)
 
@@ -62,4 +77,4 @@ Hotfixes follow the same path as any other change: branch off `development`, PR 
 - `development`:
   - Require pull request before merging.
   - Allow squash merges only.
-  - **Bypass actor for the sync workflow.** The `sync-to-development` workflow fast-forward-pushes directly to `development`, which the PR requirement above would otherwise block. In the ruleset's *Bypass list*, add the account that owns `SYNC_TOKEN` (or the GitHub App, if you switch later). Without this bypass the FF push fails and every release falls back to opening a sync PR — defeating the silent-sync design.
+  - **Bypass actor for the sync workflow.** The `sync-to-development` workflow fast-forward-pushes directly to `development`, which the PR requirement above would otherwise block. In the ruleset's *Bypass list*, add the **GitHub App** referenced by `RELEASE_BOT_APP_ID` (Bypass mode: *Always*). Without this bypass the FF push fails and every release falls back to opening a sync PR — defeating the silent-sync design.


### PR DESCRIPTION
Closes #23. Parent: #20.

Replaces the user-owned `SYNC_TOKEN` PAT with a GitHub App installation token minted at workflow runtime, so the release automation no longer depends on any individual account or PAT lifetime.

## What changed

Both workflows now mint a short-lived (~1h) installation token via [`actions/create-github-app-token@v1`](https://github.com/actions/create-github-app-token) from two secrets — `RELEASE_BOT_APP_ID` and `RELEASE_BOT_PRIVATE_KEY` — instead of reading a long-lived PAT from `SYNC_TOKEN`.

- `.github/workflows/sync-to-development.yml` — token-mint step added at the top of the job; `secrets.SYNC_TOKEN` replaced with `steps.app-token.outputs.token` everywhere it was used. Git identity now derived from the App's slug (`<app-slug>[bot]`).
- `.github/workflows/release-please.yml` — token-mint step added; `release-please-action` now receives the App token via its `token:` input. **Side benefit:** release-please's release PRs will now trigger downstream workflows (e.g. CI from #15 once it lands), which `GITHUB_TOKEN`-created PRs do *not* do.
- `CONTRIBUTING.md` — required-secrets section rewritten for the App-based flow; bypass actor on the `development` ruleset is now the App itself rather than a human account.

No changes to `release-please-config.json`, `.release-please-manifest.json`, or `CHANGELOG.md`.

## Required admin actions (post-merge)

Already done by the time you're reading this, since this PR exists *because* the App is set up:

- [x] GitHub App created in `gosodax`, installed on this repo, with `Contents: read/write`, `Pull requests: read/write`, `Metadata: read`.
- [x] Repo secrets `RELEASE_BOT_APP_ID` and `RELEASE_BOT_PRIVATE_KEY` populated.

Still TODO once this is merged:

- [ ] On the `development` branch ruleset, **swap the bypass actor**: remove the user that previously owned `SYNC_TOKEN`, add the GitHub App (Bypass mode: *Always*).
- [ ] Delete the now-unused `SYNC_TOKEN` repo secret (Settings → Secrets and variables → Actions).
- [ ] Optional: revoke the corresponding fine-grained PAT under that user's GitHub Developer Settings.

## Test plan

After this lands on \`development\` and is promoted to \`master\` (the next \`development → master\` merge), watch the Actions tab:

- [ ] \`sync master to development\` — Mint step succeeds, FF push to \`development\` succeeds, no fallback PR opens.
- [ ] \`release-please\` — Mint step succeeds, opens a release PR. The PR should be authored by `<app-slug>[bot]` (visible identity check).
- [ ] After merging the release PR, sync workflow runs again and FFs development to include the version bump.
- [ ] \`git fetch origin && git log origin/development..origin/master\` is empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)