### PR TITLE
fix(ci): pass App token to actions/checkout in sync workflow

### DIFF
--- a/.github/workflows/sync-to-development.yml
+++ b/.github/workflows/sync-to-development.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: master
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Configure git identity
         run: |
@@ -52,24 +53,21 @@ jobs:
 
       - name: Fast-forward development to master
         if: steps.sync.outputs.ff == 'true'
-        env:
-          APP_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
           git checkout development
           git merge --ff-only master
-          git push "https://x-access-token:${APP_TOKEN}@github.com/${{ github.repository }}.git" development
+          git push origin development
 
       - name: Open sync PR on divergence
         if: steps.sync.outputs.ff == 'false'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          APP_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
           BRANCH="chore/sync-master-to-development-${{ github.run_id }}"
           git checkout -b "$BRANCH" master
-          git push "https://x-access-token:${APP_TOKEN}@github.com/${{ github.repository }}.git" "$BRANCH"
+          git push origin "$BRANCH"
           gh pr create \
             --repo "${{ github.repository }}" \
             --base development \


### PR DESCRIPTION
Closes #26.

## Symptom

First real run of \`sync master to development\` (after PR #24 promoted dev to master) failed at the FF push step:

\`\`\`
remote: Permission to gosodax/builders-sodax-mcp-server.git denied to github-actions[bot].
fatal: ... The requested URL returned error: 403
\`\`\`

[Failing run](https://github.com/gosodax/builders-sodax-mcp-server/actions/runs/24938979693).

## Root cause

Two correct-in-isolation choices interacted badly:

1. **Least-privilege \`permissions: contents: read\`** (PR #22 follow-up addressing Copilot's review on #23) — \`GITHUB_TOKEN\` cannot push.
2. **URL-embedded App-token credentials** at \`git push\` time — \`git push "https://x-access-token:\${APP_TOKEN}@github.com/..."\`.

\`actions/checkout@v4\` writes \`http.https://github.com/.extraheader\` into \`.git/config\` carrying \`GITHUB_TOKEN\`'s auth. Git's HTTP transport sends the extraheader on every request to github.com, and **it takes precedence over URL-embedded credentials**. So the push was authenticated as \`github-actions[bot]\` (with read-only) instead of the App. 403.

## Fix

Pass the App token to \`actions/checkout\` directly. The extraheader then carries the App token, and plain \`git push origin <branch>\` authenticates as the App.

Why this is fine for the App token: installation tokens are ephemeral (~1h), scoped to this repo, minted fresh per run. The earlier "keep token out of checkout" advice was about the long-lived PAT; with an App token, passing to checkout is the standard pattern and produces simpler workflow code.

## What changed (3 lines net)

- \`actions/checkout\` now receives \`token: \${{ steps.app-token.outputs.token }}\`.
- FF push step: dropped the \`APP_TOKEN\` env, simplified to \`git push origin development\`.
- Sync-PR-fallback step: dropped the \`APP_TOKEN\` env (\`GH_TOKEN\` env stays for \`gh pr create\`), simplified to \`git push origin "\$BRANCH"\`.

\`release-please.yml\` is unaffected (no checkout step) and that workflow already succeeded on the same run.

## Recovery sequence after this lands

1. Squash-merge this PR into \`development\`.
2. Open \`development → master\` PR (merge commit) — when this merges, the **fixed** sync workflow runs and FFs development to master.
3. Then merge the still-open release-please PR. Its merge triggers another sync run that FFs the version bump back to development.

## Test plan

- [ ] After the dev → master merge that ships this fix, the sync workflow's FF push succeeds (no 403).
- [ ] \`git fetch origin && git log origin/development..origin/master\` is empty post-run.
- [ ] No regression on the sync-PR-fallback path (still opens a PR if FF isn't possible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)