### PR TITLE
release: promote sync workflow fix

### DIFF
--- a/.github/workflows/sync-to-development.yml
+++ b/.github/workflows/sync-to-development.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: master
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Configure git identity
         run: |
@@ -52,24 +53,21 @@ jobs:
 
       - name: Fast-forward development to master
         if: steps.sync.outputs.ff == 'true'
-        env:
-          APP_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
           git checkout development
           git merge --ff-only master
-          git push "https://x-access-token:${APP_TOKEN}@github.com/${{ github.repository }}.git" development
+          git push origin development
 
       - name: Open sync PR on divergence
         if: steps.sync.outputs.ff == 'false'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          APP_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
           BRANCH="chore/sync-master-to-development-${{ github.run_id }}"
           git checkout -b "$BRANCH" master
-          git push "https://x-access-token:${APP_TOKEN}@github.com/${{ github.repository }}.git" "$BRANCH"
+          git push origin "$BRANCH"
           gh pr create \
             --repo "${{ github.repository }}" \
             --base development \


### PR DESCRIPTION
Second \`development → master\` promotion. Brings the sync workflow 403 fix (PR #27, issue #26) to master so the next sync run actually succeeds.

## What's being promoted

\`\`\`
b2c525a  fix(ci): pass App token to actions/checkout in sync workflow (#27)
\`\`\`

Single commit on development since the last promotion. Resolves the 403 from the [previous failed sync run](https://github.com/gosodax/builders-sodax-mcp-server/actions/runs/24938979693).

## **Use "Create a merge commit" — not squash**

Click the dropdown next to the merge button and pick **Create a merge commit**. This is the same critical strategy choice as PR #24.

## Expected behavior on merge

Two workflows fire on push to master:

1. **\`sync master to development\`** — runs the **fixed** code this time. Should successfully FF \`development\` to \`master\`. No more 403.
2. **\`release-please\`** — sees PR #25 already exists with the proposed 1.2.0 release, sees one new commit since last run, **updates PR #25** to add this \`fix(ci):\` to its Bug Fixes section. Version stays at 1.2.0 (already minor-bumping; a fix doesn't move it further).

Then you can merge PR #25 normally — that creates tag \`v1.2.0\`, publishes the GitHub release, and triggers a third sync run that FFs the version bump back to development.

## Verification after merging this PR

\`\`\`bash
git fetch origin
git log origin/development..origin/master --oneline   # empty after sync runs
gh pr view 25 --repo gosodax/builders-sodax-mcp-server | grep -A2 "Bug Fixes"
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)