### PR TITLE
security: scrub internal Coolify URLs from README, gitignore .claude/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist/
 !.env.example
 .DS_Store
 .agents
+.claude/
 .github/skills/
 .github/copilot-instructions.md
 .mcpregistry_*

--- a/README.md
+++ b/README.md
@@ -169,12 +169,10 @@ pnpm start
 
 ### Environments
 
-The server runs in two Coolify environments on the tech-team infrastructure (`clf.sodax.com`):
+The server is deployed via Coolify with a branch-based promotion flow:
 
-| Environment | URL | Tracks branch |
-|-------------|-----|---------------|
-| Production | https://builders.sodax.com | `master` |
-| Staging | https://test-builders-mcp.coolify.iconblockchain.xyz | `development` |
+- **Production** — tracks `master`, serves https://builders.sodax.com
+- **Staging** — tracks `development` (internal-only)
 
 Promotion flow:
 
@@ -196,7 +194,7 @@ docker run -p 3000:3000 builders-sodax-mcp-server
 docker-compose up -d
 ```
 
-### Railway/Coolify
+### Deployment notes
 
 The included `nixpacks.toml` handles deployment automatically. Set these environment variables:
 - `PORT=3000`


### PR DESCRIPTION
Closes #18.

## Summary

- README Environments section no longer exposes `clf.sodax.com` or the staging URL `test-builders-mcp.coolify.iconblockchain.xyz`; promotion flow wording preserved.
- Renamed `### Railway/Coolify` heading to `### Deployment notes`.
- Added `.claude/` to `.gitignore` as a guardrail so local tooling state can't be accidentally committed.

## Verification

- `grep -riE "clf\.sodax|iconblockchain\.xyz|test-builders-mcp" README.md` returns empty.
- `git check-ignore .claude/settings.local.json` confirms the path is ignored.