### PR TITLE
feat: integrate solver and relay endpoints (#37)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ For clients that don't support streamable HTTP (e.g. Gemini CLI), use the SSE en
 | `sodax_get_money_market_tokens` | Money market supported tokens by chain |
 | `sodax_get_money_market_reserve_assets` | Money market reserve assets |
 
-### Intents & Solver (6 tools)
+### Intents & Solver (8 tools)
 
 | Tool | Description |
 |------|-------------|
@@ -68,6 +68,16 @@ For clients that don't support streamable HTTP (e.g. Gemini CLI), use the SSE en
 | `sodax_get_volume` | Get solver volume data (filled intents) with filtering and pagination |
 | `sodax_get_orderbook` | Get current cross-chain orderbook entries from solver |
 | `sodax_get_solver_intent` | Get solver-side intent details and fill history |
+| `sodax_get_solver_oracle` | Get the solver's oracle prices for every supported (chain, token) pair |
+| `sodax_get_solver_quote` | Get a swap quote from the solver (exact_input or exact_output) |
+
+### Intent Relay (3 tools)
+
+| Tool | Description |
+|------|-------------|
+| `sodax_relay_submit_tx` | Submit a confirmed spoke-chain tx to the intent relay for cross-chain delivery |
+| `sodax_relay_get_transaction_packets` | List every cross-chain packet emitted by a source tx |
+| `sodax_relay_get_packet` | Fetch a single relay packet by connection serial number |
 
 ### AMM & Liquidity (2 tools)
 
@@ -122,6 +132,12 @@ Once connected, try asking your AI coding assistant:
 - *"Show me cross-network solver volume for today"*
 - *"Look up this intent transaction: 0x..."*
 - *"Get intent history for this wallet address"*
+- *"Quote me 100 USDC into SODA on Sonic"*
+- *"What's the current oracle price the solver has for bnUSD on Avalanche?"*
+
+### Cross-Chain Relay
+- *"Track the relay packets for this source tx: 0x..."*
+- *"Has packet conn_sn=42 from this tx been executed yet?"*
 
 ### Money Market & Lending
 - *"What are the lending rates on SODAX money market?"*
@@ -137,7 +153,9 @@ Once connected, try asking your AI coding assistant:
 
 | Source | Type | Cache |
 |--------|------|-------|
-| SODAX API (api.sodax.com) | Live cross-network data | 2 min |
+| SODAX Backend API (api.sodax.com/v1/be) | Live cross-network data | 2 min |
+| SODAX Solver API (api.sodax.com/v1/intent) | Oracle prices + swap quotes | 2 min (oracle); none (quote) |
+| SODAX Intent Relay (xcall-relay.nw.iconblockchain.xyz) | Cross-chain packet tracking | none |
 | Aggregator | Cross-chain swap token data | 2 min |
 | GitBook (docs.sodax.com) | SDK documentation | Auto-sync |
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,6 +5,12 @@
 // SODAX API Base URL (Backend API)
 export const SODAX_API_BASE_URL = "https://api.sodax.com/v1/be";
 
+// SODAX Solver API Base URL (intent oracle + quote)
+export const SODAX_SOLVER_BASE_URL = "https://api.sodax.com/v1/intent";
+
+// SODAX Intent Relay API Base URL (xCall relay hosted by ICON)
+export const SODAX_RELAY_BASE_URL = "https://xcall-relay.nw.iconblockchain.xyz";
+
 // Cache duration in milliseconds (2 minutes for live data)
 export const CACHE_DURATION_MS = 2 * 60 * 1000;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import express, { Request, Response } from "express";
 import rateLimit from "express-rate-limit";
 import helmet from "helmet";
-import { hashClientIp, shutdownAnalytics, withAnalytics } from "./services/analytics.js";
+import { STATIC_API_TOOL_COUNT, hashClientIp, shutdownAnalytics, withAnalytics } from "./services/analytics.js";
 import { checkApiDrift } from "./services/apiDriftCheck.js";
 import { checkGitBookHealth, fetchGitBookTools } from "./services/gitbookProxy.js";
 import { logger } from "./services/logger.js";
@@ -151,7 +151,7 @@ async function runHTTP(): Promise<void> {
   app.get("/health", async (_req: Request, res: Response) => {
     const gitbookHealth = await checkGitBookHealth();
     const gitbookToolNames = await getGitBookToolNames();
-    const apiToolCount = 33; // sodax_* tools (28 in sodaxApi.ts + 5 in solverRelay.ts)
+    const apiToolCount = STATIC_API_TOOL_COUNT; // derived from analytics' TOOL_GROUPS — single source of truth
     const totalTools = apiToolCount + gitbookToolNames.length;
     res.json({
       status: "healthy",

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import { readFileSync } from "fs";
 import { fileURLToPath } from "url";
 import { dirname, join } from "path";
 import { registerSodaxApiTools } from "./tools/sodaxApi.js";
+import { registerSolverRelayTools } from "./tools/solverRelay.js";
 import { registerGitBookProxyTools, getGitBookToolNames } from "./tools/gitbookProxy.js";
 import { checkGitBookHealth, fetchGitBookTools } from "./services/gitbookProxy.js";
 import { withAnalytics, shutdownAnalytics, hashClientIp } from "./services/analytics.js";
@@ -42,6 +43,7 @@ async function createServer(clientId?: string): Promise<McpServer> {
   withAnalytics(server, clientId);
 
   registerSodaxApiTools(server);
+  registerSolverRelayTools(server);
   await registerGitBookProxyTools(server);
 
   return server;
@@ -146,7 +148,7 @@ async function runHTTP(): Promise<void> {
   app.get("/health", async (_req: Request, res: Response) => {
     const gitbookHealth = await checkGitBookHealth();
     const gitbookToolNames = await getGitBookToolNames();
-    const apiToolCount = 28; // sodax_* tools registered in sodaxApi.ts (27 + refresh_cache)
+    const apiToolCount = 33; // sodax_* tools (28 in sodaxApi.ts + 5 in solverRelay.ts)
     const totalTools = apiToolCount + gitbookToolNames.length;
     res.json({ 
       status: "healthy", 
@@ -240,7 +242,14 @@ async function runHTTP(): Promise<void> {
           "sodax_get_user_transactions",
           "sodax_get_volume",
           "sodax_get_orderbook",
-          "sodax_get_solver_intent"
+          "sodax_get_solver_intent",
+          "sodax_get_solver_oracle",
+          "sodax_get_solver_quote"
+        ],
+        relay: [
+          "sodax_relay_submit_tx",
+          "sodax_relay_get_transaction_packets",
+          "sodax_relay_get_packet"
         ],
         amm: [
           "sodax_get_amm_positions",

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import express, { Request, Response } from "express";
 import rateLimit from "express-rate-limit";
 import helmet from "helmet";
-import { STATIC_API_TOOL_COUNT, hashClientIp, shutdownAnalytics, withAnalytics } from "./services/analytics.js";
+import { STATIC_TOOL_COUNTS, hashClientIp, shutdownAnalytics, withAnalytics } from "./services/analytics.js";
 import { checkApiDrift } from "./services/apiDriftCheck.js";
 import { checkGitBookHealth, fetchGitBookTools } from "./services/gitbookProxy.js";
 import { logger } from "./services/logger.js";
@@ -151,8 +151,13 @@ async function runHTTP(): Promise<void> {
   app.get("/health", async (_req: Request, res: Response) => {
     const gitbookHealth = await checkGitBookHealth();
     const gitbookToolNames = await getGitBookToolNames();
-    const apiToolCount = STATIC_API_TOOL_COUNT; // derived from analytics' TOOL_GROUPS — single source of truth
-    const totalTools = apiToolCount + gitbookToolNames.length;
+    // Per-group breakdown derived from analytics' TOOL_GROUPS (single source
+    // of truth). `api` covers backend + solver tools; `relay` covers the
+    // intent-relay tools; `sdkDocs` is the dynamic GitBook proxy.
+    const apiToolCount = STATIC_TOOL_COUNTS.api ?? 0;
+    const relayToolCount = STATIC_TOOL_COUNTS.relay ?? 0;
+    const sdkDocsToolCount = gitbookToolNames.length;
+    const totalTools = apiToolCount + relayToolCount + sdkDocsToolCount;
     res.json({
       status: "healthy",
       service: "builders-sodax-mcp-server",
@@ -161,7 +166,8 @@ async function runHTTP(): Promise<void> {
       tools: {
         total: totalTools,
         api: apiToolCount,
-        sdkDocs: gitbookToolNames.length,
+        relay: relayToolCount,
+        sdkDocs: sdkDocsToolCount,
       },
       sdkDocsProxy: {
         healthy: gitbookHealth.healthy,

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -84,12 +84,21 @@ function resolveToolGroup(toolName: string): string {
 }
 
 /**
- * Count of statically-registered SODAX tools (everything in `TOOL_GROUPS`
- * except the `docs_*` meta-tools, which are dynamically wrapped around the
- * GitBook proxy). Use this for `/health` so the figure stays in sync as
- * tools are added/removed — no hard-coded number to drift.
+ * Per-group tool counts derived from `TOOL_GROUPS`. Keeps `/health` in sync
+ * with the analytics map automatically — no hard-coded number, no drift.
+ *
+ * Example shape: `{ api: 30, relay: 3, "sdk-docs": 3 }`. Consumers should
+ * use `STATIC_TOOL_COUNTS.api` / `STATIC_TOOL_COUNTS.relay` and **exclude**
+ * `"sdk-docs"` from any "static" total (those meta-tools are wrapped around
+ * the dynamic GitBook proxy and counted separately at runtime).
  */
-export const STATIC_API_TOOL_COUNT = Object.values(TOOL_GROUPS).filter(g => g !== "sdk-docs").length;
+export const STATIC_TOOL_COUNTS: Record<string, number> = Object.values(TOOL_GROUPS).reduce(
+  (acc, group) => {
+    acc[group] = (acc[group] ?? 0) + 1;
+    return acc;
+  },
+  {} as Record<string, number>,
+);
 
 // ── PostHog client (lazy singleton) ──────────────────────────────────
 let client: PostHog | null = null;

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -83,6 +83,14 @@ function resolveToolGroup(toolName: string): string {
   return "unknown";
 }
 
+/**
+ * Count of statically-registered SODAX tools (everything in `TOOL_GROUPS`
+ * except the `docs_*` meta-tools, which are dynamically wrapped around the
+ * GitBook proxy). Use this for `/health` so the figure stays in sync as
+ * tools are added/removed — no hard-coded number to drift.
+ */
+export const STATIC_API_TOOL_COUNT = Object.values(TOOL_GROUPS).filter(g => g !== "sdk-docs").length;
+
 // ── PostHog client (lazy singleton) ──────────────────────────────────
 let client: PostHog | null = null;
 

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -42,6 +42,13 @@ const TOOL_GROUPS: Record<string, string> = {
   sodax_get_volume: "api",
   sodax_get_orderbook: "api",
   sodax_get_solver_intent: "api",
+  sodax_get_solver_oracle: "api",
+  sodax_get_solver_quote: "api",
+
+  // SODAX intent-relay tools
+  sodax_relay_submit_tx: "relay",
+  sodax_relay_get_transaction_packets: "relay",
+  sodax_relay_get_packet: "relay",
 
   // SODAX API tools — AMM
   sodax_get_amm_positions: "api",

--- a/src/services/http.ts
+++ b/src/services/http.ts
@@ -18,6 +18,43 @@ const DEFAULT_HEADERS: Record<string, string> = {
   "Accept": "application/json",
 };
 
+/**
+ * Extract a human-readable message from an error response body so callers
+ * see *why* a request failed, not just the status code. Handles the SODAX /
+ * FastAPI shapes (`{ detail: { message } }`, `{ detail: "..." }`,
+ * `{ detail: [{ msg }] }`) plus `{ message }` / `{ error }`.
+ */
+function extractApiErrorMessage(rawBody: string): string | null {
+  const text = rawBody.trim();
+  if (!text) return null;
+
+  try {
+    const parsed: unknown = JSON.parse(text);
+    if (parsed && typeof parsed === "object") {
+      const obj = parsed as Record<string, unknown>;
+      const detail = obj.detail;
+
+      if (typeof detail === "string") return detail;
+      if (Array.isArray(detail)) {
+        const msgs = detail
+          .map(d => (d && typeof d === "object" ? (d as Record<string, unknown>).msg : null))
+          .filter((m): m is string => typeof m === "string");
+        if (msgs.length > 0) return msgs.join("; ");
+      } else if (detail && typeof detail === "object") {
+        const msg = (detail as Record<string, unknown>).message;
+        if (typeof msg === "string") return msg;
+      }
+
+      if (typeof obj.message === "string") return obj.message;
+      if (typeof obj.error === "string") return obj.error;
+    }
+  } catch {
+    // Body wasn't JSON; fall through to the raw-text snippet below.
+  }
+
+  return text.length > 300 ? `${text.slice(0, 300)}...` : text;
+}
+
 async function request<T>(
   url: string,
   options: FetchJsonOptions,
@@ -41,7 +78,10 @@ async function request<T>(
     }
 
     if (!response.ok) {
-      throw new Error(`HTTP ${response.status} ${response.statusText} for ${url}`);
+      const apiMessage = extractApiErrorMessage(await response.text().catch(() => ""));
+      const status = `HTTP ${response.status}${response.statusText ? ` ${response.statusText}` : ""}`;
+      const base = `${status} for ${url}`;
+      throw new Error(apiMessage ? `${base} - ${apiMessage}` : base);
     }
 
     return (await response.json()) as T;

--- a/src/services/relay.ts
+++ b/src/services/relay.ts
@@ -1,0 +1,124 @@
+/**
+ * SODAX Intent Relay Service
+ *
+ * Client for the cross-chain message relayer used by SODAX intents.
+ * Hosted on ICON's xCall infrastructure at xcall-relay.nw.iconblockchain.xyz.
+ *
+ * All requests are POST / with `{ action, params }` in the body; the
+ * action dispatches to one of three operations:
+ *   - submit                   (queue a spoke-chain tx for relaying)
+ *   - get_transaction_packets  (list packets emitted by a tx)
+ *   - get_packet               (fetch a single packet by conn_sn)
+ *
+ * chain_id values are intent-relay chain IDs (decimal strings), not the
+ * formal spoke chain keys — use sodax_get_relay_chain_id_map to translate.
+ */
+
+import { SODAX_RELAY_BASE_URL } from "../constants.js";
+import type {
+  RelayGetPacketResponse,
+  RelayPacketsResponse,
+  RelaySubmitResponse,
+} from "../types.js";
+
+interface SubmitParams {
+  chain_id: string;
+  tx_hash: string;
+  data?: {
+    address: string;
+    payload: string;
+  };
+}
+
+interface GetTransactionPacketsParams {
+  chain_id: string;
+  tx_hash: string;
+}
+
+interface GetPacketParams {
+  chain_id: string;
+  tx_hash: string;
+  conn_sn: string;
+}
+
+const RELAY_TIMEOUT_MS = 30_000;
+
+/**
+ * The relay returns a JSON body for every outcome, including 404 (used for
+ * "packet not found" responses on get_packet / get_transaction_packets).
+ * We parse the body regardless of status — only HTTP 5xx and unparseable
+ * responses are treated as errors.
+ */
+async function callRelay<T>(action: string, params: unknown): Promise<T> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), RELAY_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(SODAX_RELAY_BASE_URL + "/", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+      },
+      body: JSON.stringify({ action, params }),
+      signal: controller.signal,
+    });
+
+    if (response.status >= 500) {
+      throw new Error(`HTTP ${response.status} ${response.statusText}`);
+    }
+
+    return (await response.json()) as T;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+/**
+ * Submit a spoke-chain tx to the relay so it can be delivered to the
+ * destination chain. `data` is required only for split-tx chains
+ * (Solana, Bitcoin). The tx must already be confirmed on the source chain.
+ */
+export async function submitRelayTx(params: SubmitParams): Promise<RelaySubmitResponse> {
+  try {
+    return await callRelay<RelaySubmitResponse>("submit", params);
+  } catch (error) {
+    console.error("Error submitting relay tx:", error);
+    throw new Error(
+      `Failed to submit relay tx: ${error instanceof Error ? error.message : "Unknown error"}`
+    );
+  }
+}
+
+/**
+ * List every cross-chain packet emitted by the given source transaction.
+ * Use this to track relay status — a packet is complete when status === "executed".
+ */
+export async function getRelayTransactionPackets(
+  params: GetTransactionPacketsParams
+): Promise<RelayPacketsResponse> {
+  try {
+    return await callRelay<RelayPacketsResponse>("get_transaction_packets", params);
+  } catch (error) {
+    console.error("Error fetching relay transaction packets:", error);
+    throw new Error(
+      `Failed to fetch relay transaction packets: ${error instanceof Error ? error.message : "Unknown error"}`
+    );
+  }
+}
+
+/**
+ * Fetch a single packet by its connection serial number (conn_sn).
+ * Returns either the packet data or a failure message — both shapes
+ * are surfaced to the caller without throwing.
+ */
+export async function getRelayPacket(params: GetPacketParams): Promise<RelayGetPacketResponse> {
+  try {
+    return await callRelay<RelayGetPacketResponse>("get_packet", params);
+  } catch (error) {
+    console.error("Error fetching relay packet:", error);
+    throw new Error(
+      `Failed to fetch relay packet: ${error instanceof Error ? error.message : "Unknown error"}`
+    );
+  }
+}

--- a/src/services/solver.ts
+++ b/src/services/solver.ts
@@ -46,8 +46,14 @@ export async function getSolverOracle(): Promise<OraclePrice[]> {
   if (cached) return cached;
 
   try {
-    const data = await fetchJson<OraclePrice[]>(solverUrl("/oracle"));
-    const prices = Array.isArray(data) ? data : [];
+    const data = await fetchJson<unknown>(solverUrl("/oracle"));
+    if (!Array.isArray(data)) {
+      // Surface contract drift loudly rather than silently caching an empty
+      // list — a 2xx response with an unexpected shape is almost certainly
+      // an upstream change we want to know about.
+      throw new Error(`Unexpected oracle response shape: expected array, got ${typeof data}`);
+    }
+    const prices = data as OraclePrice[];
     setCache(cacheKey, prices);
     return prices;
   } catch (error) {

--- a/src/services/solver.ts
+++ b/src/services/solver.ts
@@ -1,0 +1,97 @@
+/**
+ * SODAX Solver API Service
+ *
+ * Client for the SODAX solver endpoints (intent oracle + quote).
+ * Hosted at https://api.sodax.com/v1/intent — separate from the backend
+ * API (/v1/be) and the relay service.
+ */
+
+import { SODAX_SOLVER_BASE_URL, CACHE_DURATION_MS } from "../constants.js";
+import { fetchJson } from "./http.js";
+import type { OraclePrice, QuoteRequest, QuoteResponse } from "../types.js";
+
+interface CacheEntry<T> {
+  data: T;
+  timestamp: number;
+}
+
+const cache = new Map<string, CacheEntry<unknown>>();
+
+function getCached<T>(key: string): T | null {
+  const entry = cache.get(key) as CacheEntry<T> | undefined;
+  if (!entry) return null;
+  if (Date.now() - entry.timestamp > CACHE_DURATION_MS) {
+    cache.delete(key);
+    return null;
+  }
+  return entry.data;
+}
+
+function setCache<T>(key: string, data: T): void {
+  cache.set(key, { data, timestamp: Date.now() });
+}
+
+function solverUrl(path: string): string {
+  return `${SODAX_SOLVER_BASE_URL}${path}`;
+}
+
+/**
+ * Get the solver's oracle prices for all tokens it can quote on.
+ * Returns one entry per (chainId, token) the solver tracks.
+ */
+export async function getSolverOracle(): Promise<OraclePrice[]> {
+  const cacheKey = "solver-oracle";
+  const cached = getCached<OraclePrice[]>(cacheKey);
+  if (cached) return cached;
+
+  try {
+    const data = await fetchJson<OraclePrice[]>(solverUrl("/oracle"));
+    const prices = Array.isArray(data) ? data : [];
+    setCache(cacheKey, prices);
+    return prices;
+  } catch (error) {
+    console.error("Error fetching solver oracle:", error);
+    throw new Error(
+      `Failed to fetch solver oracle prices: ${error instanceof Error ? error.message : "Unknown error"}`
+    );
+  }
+}
+
+/**
+ * Get a swap quote from the solver.
+ * The solver searches for a path between token_src and token_dst and
+ * returns a quoted_amount in the destination token's smallest unit.
+ *
+ * Errors come back as `{ detail: { code, message } }` — surfaced as
+ * a thrown Error with the upstream message attached.
+ */
+export async function getSolverQuote(request: QuoteRequest): Promise<QuoteResponse> {
+  try {
+    return await fetchJson<QuoteResponse>(solverUrl("/quote"), {
+      method: "POST",
+      body: request,
+    });
+  } catch (error) {
+    console.error("Error fetching solver quote:", error);
+    throw new Error(
+      `Failed to fetch solver quote: ${error instanceof Error ? error.message : "Unknown error"}`
+    );
+  }
+}
+
+/**
+ * Clear all cached solver data.
+ */
+export function clearSolverCache(): void {
+  cache.clear();
+}
+
+/**
+ * Get solver cache statistics.
+ */
+export function getSolverCacheStats(): { size: number; keys: string[] } {
+  return {
+    size: cache.size,
+    keys: Array.from(cache.keys()),
+  };
+}

--- a/src/tools/formatters.ts
+++ b/src/tools/formatters.ts
@@ -1,0 +1,58 @@
+/**
+ * Shared response formatters for MCP tool output.
+ *
+ * Tools accept a `format` argument ('json' | 'markdown'). JSON is a raw
+ * pretty-printed dump; markdown renders arrays of objects as tables and
+ * single objects as **key:** value lists, with long values truncated.
+ */
+
+import { ResponseFormat } from "../types.js";
+
+const TABLE_MAX_COLUMNS = 6;
+const TABLE_MAX_ROWS = 20;
+const TABLE_CELL_OBJECT_MAX = 30;
+const TABLE_CELL_STRING_MAX = 40;
+
+export function formatResponse(data: unknown, format: ResponseFormat): string {
+  if (format === ResponseFormat.MARKDOWN) {
+    return formatAsMarkdown(data);
+  }
+  return JSON.stringify(data, null, 2);
+}
+
+export function formatAsMarkdown(data: unknown): string {
+  if (Array.isArray(data)) {
+    if (data.length === 0) return "_No data available_";
+
+    if (typeof data[0] === "object" && data[0] !== null) {
+      const keys = Object.keys(data[0]).slice(0, TABLE_MAX_COLUMNS);
+      let md = `| ${keys.join(" | ")} |\n`;
+      md += `| ${keys.map(() => "---").join(" | ")} |\n`;
+      for (const item of data.slice(0, TABLE_MAX_ROWS)) {
+        const values = keys.map(k => {
+          const val = (item as Record<string, unknown>)[k];
+          if (val === null || val === undefined) return "-";
+          if (typeof val === "object") return JSON.stringify(val).slice(0, TABLE_CELL_OBJECT_MAX);
+          return String(val).slice(0, TABLE_CELL_STRING_MAX);
+        });
+        md += `| ${values.join(" | ")} |\n`;
+      }
+      if (data.length > TABLE_MAX_ROWS) {
+        md += `\n_... and ${data.length - TABLE_MAX_ROWS} more items_`;
+      }
+      return md;
+    }
+    return data.map(item => `- ${String(item)}`).join("\n");
+  }
+
+  if (typeof data === "object" && data !== null) {
+    return Object.entries(data).map(([key, value]) => {
+      if (typeof value === "object" && value !== null) {
+        return `**${key}:**\n\`\`\`json\n${JSON.stringify(value, null, 2)}\n\`\`\``;
+      }
+      return `**${key}:** ${value}`;
+    }).join("\n\n");
+  }
+
+  return String(data);
+}

--- a/src/tools/sodaxApi.ts
+++ b/src/tools/sodaxApi.ts
@@ -39,59 +39,9 @@ import {
   clearCache,
   getCacheStats
 } from "../services/sodaxApi.js";
+import { clearSolverCache, getSolverCacheStats } from "../services/solver.js";
 import { ResponseFormat } from "../types.js";
-
-/**
- * Format response based on requested format
- */
-function formatResponse(data: unknown, format: ResponseFormat): string {
-  if (format === ResponseFormat.MARKDOWN) {
-    return formatAsMarkdown(data);
-  }
-  return JSON.stringify(data, null, 2);
-}
-
-/**
- * Format data as Markdown for better readability
- */
-function formatAsMarkdown(data: unknown): string {
-  if (Array.isArray(data)) {
-    if (data.length === 0) return "_No data available_";
-    
-    // Try to create a table for arrays of objects
-    if (typeof data[0] === "object" && data[0] !== null) {
-      const keys = Object.keys(data[0]).slice(0, 6); // Limit columns
-      let md = `| ${keys.join(" | ")} |\n`;
-      md += `| ${keys.map(() => "---").join(" | ")} |\n`;
-      for (const item of data.slice(0, 20)) { // Limit rows
-        const values = keys.map(k => {
-          const val = (item as Record<string, unknown>)[k];
-          if (val === null || val === undefined) return "-";
-          if (typeof val === "object") return JSON.stringify(val).slice(0, 30);
-          return String(val).slice(0, 40);
-        });
-        md += `| ${values.join(" | ")} |\n`;
-      }
-      if (data.length > 20) {
-        md += `\n_... and ${data.length - 20} more items_`;
-      }
-      return md;
-    }
-    return data.map(item => `- ${String(item)}`).join("\n");
-  }
-  
-  if (typeof data === "object" && data !== null) {
-    const entries = Object.entries(data);
-    return entries.map(([key, value]) => {
-      if (typeof value === "object" && value !== null) {
-        return `**${key}:**\n\`\`\`json\n${JSON.stringify(value, null, 2)}\n\`\`\``;
-      }
-      return `**${key}:** ${value}`;
-    }).join("\n\n");
-  }
-  
-  return String(data);
-}
+import { formatResponse } from "./formatters.js";
 
 /**
  * Register all SODAX API tools with the MCP server
@@ -996,12 +946,15 @@ export function registerSodaxApiTools(server: McpServer): void {
     {},
     { readOnlyHint: false, destructiveHint: false, idempotentHint: true },
     async () => {
-      const statsBefore = getCacheStats();
+      const apiBefore = getCacheStats();
+      const solverBefore = getSolverCacheStats();
       clearCache();
+      clearSolverCache();
+      const total = apiBefore.size + solverBefore.size;
       return {
         content: [{
           type: "text",
-          text: `Cache cleared. ${statsBefore.size} cached entries removed.`
+          text: `Cache cleared. ${total} cached entries removed (${apiBefore.size} api, ${solverBefore.size} solver).`
         }]
       };
     }

--- a/src/tools/sodaxApi.ts
+++ b/src/tools/sodaxApi.ts
@@ -1098,7 +1098,7 @@ export function registerSodaxApiTools(server: McpServer): void {
   // Bonus Tool: Refresh Cache
   server.tool(
     "sodax_refresh_cache",
-    "Clear the cached API data to force fresh fetches on next requests",
+    "Clear both the backend API cache and the solver oracle cache to force fresh fetches on next requests. Reports the number of entries cleared per cache.",
     {},
     { readOnlyHint: false, destructiveHint: false, idempotentHint: true },
     async () => {

--- a/src/tools/solverRelay.ts
+++ b/src/tools/solverRelay.ts
@@ -250,7 +250,11 @@ export function registerSolverRelayTools(server: McpServer): void {
     {
       chainId: z.string().describe("REQUIRED: Intent-relay chain ID of the source chain (decimal string)"),
       txHash: z.string().describe("REQUIRED: The source-chain transaction hash"),
-      connSn: z.string().describe("REQUIRED: Connection serial number identifying the packet within the tx"),
+      connSn: z.coerce
+        .string()
+        .describe(
+          "REQUIRED: Connection serial number identifying the packet within the tx. Accepts string or number (numeric values are coerced — convenient for piping back a previously-fetched packet's `conn_sn` field).",
+        ),
       format: z
         .nativeEnum(ResponseFormat)
         .optional()

--- a/src/tools/solverRelay.ts
+++ b/src/tools/solverRelay.ts
@@ -1,0 +1,238 @@
+/**
+ * Solver + Intent Relay Tools
+ *
+ * MCP tool definitions for the SODAX solver (oracle, quote) and the
+ * cross-chain intent relay (submit, get_transaction_packets, get_packet).
+ *
+ * Solver lives at https://api.sodax.com/v1/intent (separate from /v1/be).
+ * Relay lives at https://xcall-relay.nw.iconblockchain.xyz (ICON xCall).
+ */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+import { getSolverOracle, getSolverQuote } from "../services/solver.js";
+import {
+  getRelayPacket,
+  getRelayTransactionPackets,
+  submitRelayTx,
+} from "../services/relay.js";
+import { ResponseFormat } from "../types.js";
+import { formatResponse } from "./formatters.js";
+
+const READ_ONLY: ToolAnnotations = {
+  readOnlyHint: true,
+  destructiveHint: false,
+  openWorldHint: true,
+};
+
+// Relay submit isn't destructive in the typical sense — the tx is already
+// finalized on the source chain; submit just enqueues the relay packet.
+// Re-submitting the same tx is a no-op on the network side, hence idempotent.
+const RELAY_SUBMIT: ToolAnnotations = {
+  readOnlyHint: false,
+  destructiveHint: false,
+  idempotentHint: true,
+  openWorldHint: true,
+};
+
+export function registerSolverRelayTools(server: McpServer): void {
+  // ── Solver: oracle ──────────────────────────────────────────────────
+  server.tool(
+    "sodax_get_solver_oracle",
+    "Get the solver's oracle prices for every (chain, token) pair it can quote. Useful for sanity-checking quote amounts against USD prices the solver is using.",
+    {
+      chainId: z.string().optional()
+        .describe("Filter results to a single intent-relay chain ID (decimal string, e.g. '146' for Sonic). Call sodax_get_relay_chain_id_map to translate."),
+      symbol: z.string().optional()
+        .describe("Filter by token symbol (case-insensitive exact match, e.g. 'SODA', 'bnUSD')"),
+      format: z.nativeEnum(ResponseFormat).optional().default(ResponseFormat.MARKDOWN)
+        .describe("Response format: 'json' for raw data or 'markdown' for formatted text"),
+    },
+    READ_ONLY,
+    async ({ chainId, symbol, format }) => {
+      try {
+        const all = await getSolverOracle();
+        const filtered = all.filter(p => {
+          if (chainId && p.chainId !== chainId) return false;
+          if (symbol && p.symbol.toLowerCase() !== symbol.toLowerCase()) return false;
+          return true;
+        });
+        const header = `## Solver Oracle Prices\n\n${filtered.length} of ${all.length} prices${chainId ? ` on chain ${chainId}` : ""}${symbol ? ` for ${symbol}` : ""}\n\n`;
+        return {
+          content: [{
+            type: "text",
+            text: header + formatResponse(filtered, format),
+          }],
+        };
+      } catch (error) {
+        return {
+          content: [{ type: "text", text: `Error: ${error instanceof Error ? error.message : "Unknown error"}` }],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // ── Solver: quote ───────────────────────────────────────────────────
+  server.tool(
+    "sodax_get_solver_quote",
+    "Get a swap quote from the SODAX solver. IMPORTANT: tokenSrc/tokenDst must be hub-chain asset addresses — the SODAX hub is Sonic (chainId 146); spoke-chain token addresses are rejected with 'not compatible with the quote service'. Call sodax_get_solver_oracle with chainId='146' to look up valid token addresses. quote_type='exact_input' quotes the destination amount you'd receive; 'exact_output' quotes the source amount you'd need to supply. Returns 'No path found' if the solver can't route between the tokens.",
+    {
+      tokenSrc: z.string()
+        .describe("REQUIRED: Source token address (the token you're spending). Must be a hub-chain asset address (chainId 146) — look one up via sodax_get_solver_oracle."),
+      tokenDst: z.string()
+        .describe("REQUIRED: Destination token address (the token you want to receive). Must be a hub-chain asset address (chainId 146) — look one up via sodax_get_solver_oracle."),
+      amount: z.string()
+        .describe("REQUIRED: Amount in the smallest unit of the input token (for exact_input) or output token (for exact_output). String to preserve precision."),
+      quoteType: z.enum(["exact_input", "exact_output"]).optional().default("exact_input")
+        .describe("'exact_input' (default): given input amount, quote output amount. 'exact_output': given output amount, quote input amount required."),
+      format: z.nativeEnum(ResponseFormat).optional().default(ResponseFormat.MARKDOWN)
+        .describe("Response format: 'json' for raw data or 'markdown' for formatted text"),
+    },
+    READ_ONLY,
+    async ({ tokenSrc, tokenDst, amount, quoteType, format }) => {
+      try {
+        const quote = await getSolverQuote({
+          token_src: tokenSrc,
+          token_dst: tokenDst,
+          amount,
+          quote_type: quoteType,
+        });
+        const header = `## Solver Quote\n\n**${quoteType}** ${amount} ${tokenSrc.slice(0, 10)}... → ${tokenDst.slice(0, 10)}...\n\n`;
+        return {
+          content: [{
+            type: "text",
+            text: header + formatResponse(quote, format),
+          }],
+        };
+      } catch (error) {
+        return {
+          content: [{ type: "text", text: `Error: ${error instanceof Error ? error.message : "Unknown error"}` }],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // ── Relay: submit ───────────────────────────────────────────────────
+  server.tool(
+    "sodax_relay_submit_tx",
+    "Submit a confirmed spoke-chain transaction to the SODAX intent relay so it can be delivered to the destination chain. The tx must already be finalized on the source chain. Re-submitting the same tx is a no-op. For split-tx chains (Solana, Bitcoin) supply the optional `data` argument.",
+    {
+      chainId: z.string()
+        .describe("REQUIRED: Intent-relay chain ID of the source chain (decimal string, e.g. '146' for Sonic, '2' for Ethereum). Call sodax_get_relay_chain_id_map to translate from a chain key."),
+      txHash: z.string()
+        .describe("REQUIRED: The confirmed transaction hash on the source chain"),
+      data: z.object({
+        address: z.string().describe("Contract address for split-tx chains"),
+        payload: z.string().describe("Hex payload for split-tx chains"),
+      }).optional()
+        .describe("Required only for split-tx chains (Solana, Bitcoin). Omit for EVM chains."),
+      format: z.nativeEnum(ResponseFormat).optional().default(ResponseFormat.MARKDOWN)
+        .describe("Response format: 'json' for raw data or 'markdown' for formatted text"),
+    },
+    RELAY_SUBMIT,
+    async ({ chainId, txHash, data, format }) => {
+      try {
+        const result = await submitRelayTx({
+          chain_id: chainId,
+          tx_hash: txHash,
+          ...(data ? { data } : {}),
+        });
+        return {
+          content: [{
+            type: "text",
+            text: `## Relay Submit\n\n` + formatResponse(result, format),
+          }],
+        };
+      } catch (error) {
+        return {
+          content: [{ type: "text", text: `Error: ${error instanceof Error ? error.message : "Unknown error"}` }],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // ── Relay: get transaction packets ──────────────────────────────────
+  server.tool(
+    "sodax_relay_get_transaction_packets",
+    "List every cross-chain packet emitted by a given source transaction. Use this to track relay status — a packet is complete when status='executed' and dst_tx_hash is populated.",
+    {
+      chainId: z.string()
+        .describe("REQUIRED: Intent-relay chain ID of the source chain (decimal string, e.g. '146'). Call sodax_get_relay_chain_id_map to translate from a chain key."),
+      txHash: z.string()
+        .describe("REQUIRED: The source-chain transaction hash whose packets you want to inspect"),
+      format: z.nativeEnum(ResponseFormat).optional().default(ResponseFormat.MARKDOWN)
+        .describe("Response format: 'json' for raw data or 'markdown' for formatted text"),
+    },
+    READ_ONLY,
+    async ({ chainId, txHash, format }) => {
+      try {
+        const result = await getRelayTransactionPackets({
+          chain_id: chainId,
+          tx_hash: txHash,
+        });
+        const header = `## Relay Packets for ${txHash.slice(0, 10)}...\n\n`;
+        if (!result.success) {
+          return {
+            content: [{
+              type: "text",
+              text: header + formatResponse(result, format),
+            }],
+          };
+        }
+        const summary = `${result.data.length} packet(s) found\n\n`;
+        return {
+          content: [{
+            type: "text",
+            text: header + summary + formatResponse(result.data, format),
+          }],
+        };
+      } catch (error) {
+        return {
+          content: [{ type: "text", text: `Error: ${error instanceof Error ? error.message : "Unknown error"}` }],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // ── Relay: get packet ───────────────────────────────────────────────
+  server.tool(
+    "sodax_relay_get_packet",
+    "Fetch a single relay packet by its connection serial number (conn_sn). Returns the packet data on success or a `{success:false, message}` shape if the packet isn't found.",
+    {
+      chainId: z.string()
+        .describe("REQUIRED: Intent-relay chain ID of the source chain (decimal string)"),
+      txHash: z.string()
+        .describe("REQUIRED: The source-chain transaction hash"),
+      connSn: z.string()
+        .describe("REQUIRED: Connection serial number identifying the packet within the tx"),
+      format: z.nativeEnum(ResponseFormat).optional().default(ResponseFormat.MARKDOWN)
+        .describe("Response format: 'json' for raw data or 'markdown' for formatted text"),
+    },
+    READ_ONLY,
+    async ({ chainId, txHash, connSn, format }) => {
+      try {
+        const result = await getRelayPacket({
+          chain_id: chainId,
+          tx_hash: txHash,
+          conn_sn: connSn,
+        });
+        return {
+          content: [{
+            type: "text",
+            text: `## Relay Packet (conn_sn=${connSn})\n\n` + formatResponse(result, format),
+          }],
+        };
+      } catch (error) {
+        return {
+          content: [{ type: "text", text: `Error: ${error instanceof Error ? error.message : "Unknown error"}` }],
+          isError: true,
+        };
+      }
+    }
+  );
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -187,3 +187,78 @@ export interface TokenSupply {
   priceUsd?: number;
   marketCapUsd?: number;
 }
+
+/**
+ * Solver oracle price entry — one per (chainId, token) pair the solver tracks.
+ */
+export interface OraclePrice {
+  address: string;
+  chainId: string;
+  symbol: string;
+  priceUsd: number;
+  decimals: number;
+  updatedAt: number;
+}
+
+/**
+ * Solver quote request. `quote_type` controls which side is the
+ * provided amount — `exact_input` quotes the destination amount,
+ * `exact_output` quotes the source amount required.
+ */
+export interface QuoteRequest {
+  token_src: string;
+  token_dst: string;
+  amount: string;
+  quote_type: "exact_input" | "exact_output";
+}
+
+/**
+ * Solver quote response. `quoted_amount` is in the smallest unit
+ * of the destination token (for exact_input) or the source token
+ * (for exact_output).
+ */
+export interface QuoteResponse {
+  quoted_amount: string;
+}
+
+/**
+ * Intent Relay packet — one cross-chain message in flight.
+ * `status === 'executed'` means the destination chain has applied it.
+ */
+export interface RelayPacketData {
+  src_chain_id: number;
+  src_tx_hash: string;
+  src_address: string;
+  status: "pending" | "validating" | "executing" | "executed";
+  dst_chain_id: number;
+  conn_sn: number;
+  dst_address: string;
+  dst_tx_hash: string;
+  signatures: string[];
+  payload: string;
+}
+
+/**
+ * Response for the relay `submit` action.
+ */
+export interface RelaySubmitResponse {
+  success: boolean;
+  message: string;
+}
+
+/**
+ * Response for the relay `get_transaction_packets` action.
+ * Returns every packet emitted by the given source transaction.
+ */
+export interface RelayPacketsResponse {
+  success: boolean;
+  data: RelayPacketData[];
+}
+
+/**
+ * Response for the relay `get_packet` action.
+ * Returns a single packet by its connection serial number.
+ */
+export type RelayGetPacketResponse =
+  | { success: true; data: RelayPacketData }
+  | { success: false; message: string };

--- a/src/types.ts
+++ b/src/types.ts
@@ -231,6 +231,12 @@ export interface RelayPacketData {
   src_address: string;
   status: "pending" | "validating" | "executing" | "executed";
   dst_chain_id: number;
+  /**
+   * Connection serial number. Wire format from the relay is numeric, but the
+   * relay's *request* params (and `GetPacketParams.conn_sn`) take it as a
+   * string for URL/JSON consistency. Convert via `String(packet.conn_sn)`
+   * when feeding a previously-fetched packet back into a request.
+   */
   conn_sn: number;
   dst_address: string;
   dst_tx_hash: string;
@@ -248,12 +254,16 @@ export interface RelaySubmitResponse {
 
 /**
  * Response for the relay `get_transaction_packets` action.
- * Returns every packet emitted by the given source transaction.
+ *
+ * Discriminated by `success`:
+ *  - on success → `{ success: true; data: RelayPacketData[] }`
+ *  - on failure → `{ success: false; message: string }` (mirrors `RelayGetPacketResponse`)
+ *
+ * The relay returns the failure shape with HTTP 404 (which `callRelay` parses
+ * normally rather than throwing), so callers must branch on `success` before
+ * touching `data`.
  */
-export interface RelayPacketsResponse {
-  success: boolean;
-  data: RelayPacketData[];
-}
+export type RelayPacketsResponse = { success: true; data: RelayPacketData[] } | { success: false; message: string };
 
 /**
  * Response for the relay `get_packet` action.


### PR DESCRIPTION
Closes #37.

## Summary
- Adds 2 MCP tools for the SODAX solver (`/v1/intent/oracle`, `/v1/intent/quote`): `sodax_get_solver_oracle` and `sodax_get_solver_quote`.
- Adds 3 MCP tools for the cross-chain intent relay (hosted at `xcall-relay.nw.iconblockchain.xyz` — single `POST /` dispatched by `action`): `sodax_relay_submit_tx`, `sodax_relay_get_transaction_packets`, `sodax_relay_get_packet`. The relay returns HTTP 404 with a valid JSON body for "not found", so `src/services/relay.ts` uses a raw fetch that only treats 5xx as errors.
- Extracts duplicated markdown/JSON formatters into `src/tools/formatters.ts`, wires the solver's separate cache into `sodax_refresh_cache`, and upgrades `src/services/http.ts` to surface upstream API error messages (`detail.message`, `message`, `error`) instead of just the HTTP status.
- README, `/api` listing, and analytics tool groups updated; total tool count goes 28 → 33 api tools (38 with SDK docs).

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm check:drift` reports the same 12 pre-existing issues on `/solver/orderbook` and `/intent/tx` — no new drift
- [x] End-to-end smoke test via MCP JSON-RPC on each of the 5 new tools (oracle returns ~438 prices, quote returns real `quoted_amount`, all 3 relay actions return their expected shapes)
- [x] `sodax_refresh_cache` reports both api + solver cache totals
- [x] Reviewer: confirm tool descriptions read well in your MCP client