### PR TITLE
fix(ci): exclude package.json from biome formatter

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -20,7 +20,8 @@
       "**/.git",
       "**/.DS_Store",
       "**/.idea",
-      "pnpm-lock.yaml"
+      "pnpm-lock.yaml",
+      "package.json"
     ]
   },
   "formatter": {


### PR DESCRIPTION
## Summary
- Adds `package.json` to Biome's `files.ignore` list so the formatter no longer checks it.

## Why
The CI on release PR #43 failed because release-please's JSON writer rewrites `package.json` with multi-line arrays (e.g. `"extends": [\n "..."\n]`), but our Biome formatter (`lineWidth: 120`) wants those short arrays inline — so every release PR will fail CI until this is fixed.

Excluding `package.json` from Biome is the cleanest fix: pnpm/npm/release-please all own this file's formatting, and the linter has no real opinions about it that aren't already enforced by JSON syntax itself.

#43 was unblocked separately by reformatting `package.json` inline on the release branch; this PR prevents the same failure on future releases.

## Test plan
- [ ] CI passes on this PR
- [ ] Next release PR (after this lands) does not fail biome check on `package.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)