### PR TITLE
release: promote development to master

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,11 @@
 # PostHog Analytics (optional — tracking is silently skipped when unset)
 # Get your API key at: https://eu.posthog.com → Settings → Project API Key
 POSTHOG_API_KEY=
-POSTHOG_SERVER_NAME=builders-mcp
-POSTHOG_DISTINCT_ID=sodax-builders-mcp
+# Identifiers used to tag PostHog events. Leave blank to use the
+# built-in defaults from src/services/analytics.ts. Override only if
+# you're running your own PostHog project against this server.
+POSTHOG_SERVER_NAME=
+POSTHOG_DISTINCT_ID=
 
 # Server configuration
 PORT=3000

--- a/README.md
+++ b/README.md
@@ -263,7 +263,6 @@ The included `nixpacks.toml` handles deployment automatically. Set these environ
 
 - **SODAX** — [sodax.com](https://sodax.com)
 - **SDK Documentation** — [docs.sodax.com](https://docs.sodax.com) (proxied automatically)
-- **Marketing MCP Server** — For marketing teams: `https://marketing.sodax.com/mcp`
 
 ## License
 

--- a/biome.json
+++ b/biome.json
@@ -20,7 +20,8 @@
       "**/.git",
       "**/.DS_Store",
       "**/.idea",
-      "pnpm-lock.yaml"
+      "pnpm-lock.yaml",
+      "package.json"
     ]
   },
   "formatter": {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -18,6 +18,13 @@
         { "type": "ci", "section": "Continuous Integration" },
         { "type": "test", "section": "Tests", "hidden": true },
         { "type": "chore", "section": "Miscellaneous" }
+      ],
+      "extra-files": [
+        {
+          "type": "json",
+          "path": "server.json",
+          "jsonpath": "$.version"
+        }
       ]
     }
   }

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.gosodax/builders-mcp",
   "title": "SODAX Builders MCP",
   "description": "Cross-network DeFi API data, AMM analytics, and SDK docs for 17+ networks.",
-  "version": "1.1.0",
+  "version": "1.3.0",
   "repository": {
     "url": "https://github.com/gosodax/builders-sodax-mcp-server",
     "source": "github"

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,10 @@ import { registerSolverRelayTools } from "./tools/solverRelay.js";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
+const { version: SERVER_VERSION } = JSON.parse(readFileSync(join(__dirname, "..", "package.json"), "utf8")) as {
+  version: string;
+};
+
 /**
  * Creates a fully configured McpServer instance.
  * Used per-request in HTTP mode to avoid transport conflicts
@@ -36,7 +40,7 @@ const __dirname = dirname(__filename);
 async function createServer(clientId?: string): Promise<McpServer> {
   const server = new McpServer({
     name: "builders-sodax-mcp-server",
-    version: "1.1.0",
+    version: SERVER_VERSION,
   });
 
   // Wrap server.tool() so every tool call is tracked in PostHog
@@ -161,7 +165,7 @@ async function runHTTP(): Promise<void> {
     res.json({
       status: "healthy",
       service: "builders-sodax-mcp-server",
-      version: "1.1.0",
+      version: SERVER_VERSION,
       uptime_seconds: Math.floor(process.uptime()),
       tools: {
         total: totalTools,
@@ -231,7 +235,7 @@ async function runHTTP(): Promise<void> {
 
     res.json({
       name: "SODAX Builders MCP Server",
-      version: "1.1.0",
+      version: SERVER_VERSION,
       description:
         "Live cross-network DeFi API data, AMM analytics, money market insights, and auto-updating SDK docs for 17+ networks",
       endpoints: { mcp: "/mcp", sse: "/sse", messages: "/messages", health: "/health", api: "/api" },


### PR DESCRIPTION
Promotes the current state of \`development\` to \`master\` to trigger the release-please flow.

## Commits included

- \`abe9e55\` chore: remove internal Marketing MCP link, blank PostHog defaults in .env.example (#50)
- \`91bb10f\` fix: sync runtime version from package.json (#48)
- \`0eb3b2d\` fix(ci): exclude package.json from biome formatter (#44)

## Expected release

Two \`fix:\` commits, so release-please should open a patch release PR (\`v1.3.1\`).

This will be the first release where:
- \`server.json\` auto-bumps alongside \`package.json\` (#48 added it to release-please's \`extra-files\`).
- The runtime \`/health\` and \`/api\` endpoints report the version straight from \`package.json\` (#48).
- \`package.json\` formatting is exempt from biome (#44), so the release PR's CI won't fail like #43's did.

## Merge instructions

⚠️ Per CONTRIBUTING.md, this PR must be merged with **"Create a merge commit"** (NOT squash) so the sync-back to \`development\` stays a clean fast-forward.