### PR TITLE
fix(docker): add --ignore-scripts to prod install (Coolify deploy fix)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,11 @@ RUN apk add --no-cache curl && \
 # Copy package files
 COPY package.json pnpm-lock.yaml* ./
 
-# Install production dependencies only
-RUN pnpm install --prod --frozen-lockfile
+# Install production dependencies only.
+# --ignore-scripts: skip lifecycle hooks (e.g. the husky `prepare` script,
+# which would fail here because husky is a devDependency). No prod dep
+# in this project requires postinstall scripts.
+RUN pnpm install --prod --frozen-lockfile --ignore-scripts
 
 # Copy built files
 COPY --from=builder /app/dist ./dist


### PR DESCRIPTION
## Summary
- \`Dockerfile\` line 33: \`pnpm install --prod --frozen-lockfile\` → \`pnpm install --prod --frozen-lockfile --ignore-scripts\`
- Comment explaining the husky reason so future readers don't strip the flag.

## Why
Coolify staging and prod deploys are failing at the prod-install stage:

\`\`\`
sh: 1: husky: not found
ELIFECYCLE  Command failed.
exit code: 1
\`\`\`

\`pnpm install --prod\` skips devDeps → husky isn't installed → the \`prepare\` script in package.json (which runs \`husky\`) crashes → install aborts. \`--ignore-scripts\` skips the lifecycle hooks, which is what we want in a production container anyway.

## Test plan
- [x] Reproduced the failure locally with the exact Dockerfile command.
- [x] Confirmed fix locally: \`pnpm install --prod --frozen-lockfile --ignore-scripts\` completes cleanly (135 packages).
- [x] Built the full Dockerfile end-to-end (\`docker build .\`) — both stages succeed.
- [ ] After merge to development, watch Coolify staging deploy succeed.
- [ ] After dev → master promotion + deploy, confirm prod also recovers.

## Why CI didn't catch it
CI runs \`pnpm install --frozen-lockfile\` (no \`--prod\`), so husky is installed and the prepare script works. CI never builds the Dockerfile. Will be addressed by a separate PR for #54 (add docker-build job to CI).

## Hotfix promotion
After this lands on \`development\`, will open a fresh \`development → master\` PR to ship the fix to prod. (PR #51 already merged before this fix existed.)

Closes #53.
Parent: icon-project/ICON-Projects-Planning#683.
Related: #54 (CI guard follow-up).