### PR TITLE
release: promote Dockerfile fix to master (hotfix #55)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,11 @@ RUN apk add --no-cache curl && \
 # Copy package files
 COPY package.json pnpm-lock.yaml* ./
 
-# Install production dependencies only
-RUN pnpm install --prod --frozen-lockfile
+# Install production dependencies only.
+# --ignore-scripts: skip lifecycle hooks (e.g. the husky `prepare` script,
+# which would fail here because husky is a devDependency). No prod dep
+# in this project requires postinstall scripts.
+RUN pnpm install --prod --frozen-lockfile --ignore-scripts
 
 # Copy built files
 COPY --from=builder /app/dist ./dist


### PR DESCRIPTION
Promotes the Coolify Dockerfile fix from development to master so prod can recover.

## Commits included

- \`d9899dc\` fix(docker): skip lifecycle scripts on prod install (#55)

## Expected release

One \`fix:\` commit → release-please will open a \`v1.3.2\` patch release PR after this merges.

## Why this matters

Prod Coolify deploys are currently failing the same way staging was (#53) — \`pnpm install --prod --frozen-lockfile\` aborts on the husky \`prepare\` script. Merging this PR unblocks the next prod deploy.

## Merge instructions

⚠️ Per CONTRIBUTING.md, this PR must be merged with **"Create a merge commit"** (NOT squash) so the sync-back to \`development\` stays a clean fast-forward.

Closes #53.