### PR TITLE
test: trigger Coolify staging deploy after git source migration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,4 @@
+# Coolify pipeline smoke test: 2026-05-21. No-op edit — safe to remove.
 services:
   builders-sodax-mcp-server:
     build: .


### PR DESCRIPTION
## Why
Coolify's git source for this project was just switched from public to a GitHub App. This PR exists only to push a no-op commit to \`development\` and confirm the new auth path resolves and the staging pipeline still works end-to-end.

## Change
- One comment line added to the top of \`docker-compose.yml\` (\`# Coolify pipeline smoke test...\`).
- Nothing else touched. No code, no deps, no config.

## After merge
1. Watch Coolify staging redeploy from \`development\`.
2. If it succeeds: open a follow-up to remove the comment marker (or just leave it — it's harmless).
3. If it fails: investigate the new git-app auth or any pipeline difference vs the previous public source.

## Mirroring note
Skipping the source-issue + ICON-mirror dance for this one. It's a literal throwaway deploy probe, not real work. Let me know if you'd rather I file it as an issue anyway.