### PR TITLE
feat: Discord alerts, CI checks (drift + docker build), and .env loading (#16, #38, #54)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+dist
+.git
+.github
+*.log
+.DS_Store
+.env
+.env.*
+!.env.example

--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,8 @@ PORT=3000
 
 # Log verbosity. One of: trace, debug, info, warn, error, fatal.
 LOG_LEVEL=info
+
+# Discord webhook for runtime alerts (optional — empty/unset = silent):
+# server status (start/stop), significant errors, and API-drift summaries.
+# Set on the PROD deployment; leave blank locally and on staging to stay quiet.
+DISCORD_WEBHOOK_URL=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
     branches:
       - master
       - development
-    types: [opened, synchronize]
+    types: [opened, synchronize, reopened]
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,3 +45,26 @@ jobs:
 
       - name: Test
         run: pnpm test
+
+  docker-build:
+    name: Docker build
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Builds the same Dockerfile Coolify deploys — both the `builder` and the
+      # final prod stage. Catches prod-install / image regressions in CI instead
+      # of at deploy time (#54). No push; GitHub Actions cache keeps warm runs fast.
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/drift-check.yml
+++ b/.github/workflows/drift-check.yml
@@ -1,0 +1,38 @@
+name: Drift Check
+
+on:
+  pull_request:
+  push:
+    branches:
+      - development
+      - master
+  schedule:
+    # Daily at 09:00 UTC — surfaces upstream-only drift even when no PR is open.
+    - cron: "0 9 * * *"
+  workflow_dispatch:
+
+jobs:
+  drift:
+    name: API Drift Check
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Check API drift
+        run: pnpm check:drift

--- a/.github/workflows/drift-check.yml
+++ b/.github/workflows/drift-check.yml
@@ -37,5 +37,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # Advisory on PRs: upstream API drift shouldn't red-X (or block) an
+      # otherwise-unrelated PR. The push (development/master), scheduled, and
+      # manual runs stay authoritative and fail on drift.
       - name: Check API drift
+        continue-on-error: ${{ github.event_name == 'pull_request' }}
         run: pnpm check:drift

--- a/.github/workflows/drift-check.yml
+++ b/.github/workflows/drift-check.yml
@@ -2,6 +2,9 @@ name: Drift Check
 
 on:
   pull_request:
+    branches:
+      - development
+      - master
   push:
     branches:
       - development

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine AS builder
+FROM node:22-alpine AS builder
 
 WORKDIR /app
 
@@ -18,7 +18,7 @@ COPY . .
 RUN pnpm build
 
 # Production stage
-FROM node:20-alpine
+FROM node:22-alpine
 
 WORKDIR /app
 
@@ -48,4 +48,4 @@ ENV NODE_ENV=production
 
 USER appuser
 
-CMD ["node", "dist/index.js"]
+CMD ["node", "--env-file-if-exists=.env", "dist/index.js"]

--- a/README.md
+++ b/README.md
@@ -206,12 +206,18 @@ Don't make a habit of it — CI will still enforce the same checks on the PR.
 
 ### Environment Variables
 
+The server auto-loads a `.env` file on startup (via Node's `--env-file-if-exists`
+flag — requires Node ≥ 22.9.0). Copy `.env.example` to `.env` for local development;
+if no `.env` exists, every variable falls back to the default below. In production,
+Coolify injects these directly into the process environment.
+
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `PORT` | `3000` | Server port |
 | `TRANSPORT` | `http` | Transport mode (`http` or `stdio`) |
 | `NODE_ENV` | - | Set to `production` for deployment |
 | `LOG_LEVEL` | `info` | Log verbosity. One of `trace`, `debug`, `info`, `warn`, `error`, `fatal`. |
+| `DISCORD_WEBHOOK_URL` | - | Discord webhook for runtime alerts: server status (start/stop), significant errors (uncaught/unhandled), and API-drift summaries. Empty/unset = silent (staging/local). |
 
 ## Deployment
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-# Coolify pipeline smoke test: 2026-05-21. No-op edit — safe to remove.
 services:
   builders-sodax-mcp-server:
     build: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,12 +3,15 @@ services:
   builders-sodax-mcp-server:
     build: .
     container_name: builders-sodax-mcp-server
-    env_file: .env
+    # .env is optional — if absent, the defaults below apply (no error).
+    env_file:
+      - path: .env
+        required: false
     ports:
-      - "${PORT}:${PORT}"
+      - "${PORT:-3000}:${PORT:-3000}"
     environment:
       - NODE_ENV=production
-      - PORT=${PORT}
+      - PORT=${PORT:-3000}
       - TRANSPORT=http
     restart: unless-stopped
     logging:
@@ -17,7 +20,7 @@ services:
         max-size: "10m"
         max-file: "5"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:${PORT}/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:${PORT:-3000}/health"]
       interval: 30s
       timeout: 10s
       retries: 10

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,5 +1,6 @@
 [phases.setup]
-nixPkgs = ["nodejs_20"]
+# nodejs_22: required for the `--env-file-if-exists` flag in the start cmd below.
+nixPkgs = ["nodejs_22"]
 
 [phases.install]
 cmds = ["corepack enable", "corepack prepare pnpm@9.15.0 --activate", "pnpm install --frozen-lockfile"]
@@ -8,4 +9,6 @@ cmds = ["corepack enable", "corepack prepare pnpm@9.15.0 --activate", "pnpm inst
 cmds = ["pnpm build"]
 
 [start]
-cmd = "node dist/index.js"
+# Load .env if present (Coolify normally injects env vars directly; the flag
+# no-ops when no .env file exists, so this is safe either way).
+cmd = "node --env-file-if-exists=.env dist/index.js"

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "type": "module",
   "main": "dist/index.js",
   "scripts": {
-    "start": "node dist/index.js",
-    "dev": "NODE_ENV=development tsx watch src/index.ts",
+    "start": "node --env-file-if-exists=.env dist/index.js",
+    "dev": "NODE_ENV=development tsx watch --env-file-if-exists=.env src/index.ts",
     "build": "pnpm exec tsc && cp -r src/public dist/",
-    "check:drift": "tsx src/scripts/checkDrift.ts",
+    "check:drift": "tsx --env-file-if-exists=.env src/scripts/checkDrift.ts",
     "checkTs": "tsc --noEmit",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
@@ -19,7 +19,7 @@
   },
   "packageManager": "pnpm@9.15.0",
   "engines": {
-    "node": ">=20"
+    "node": ">=22.9.0"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.26.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import rateLimit from "express-rate-limit";
 import helmet from "helmet";
 import { STATIC_TOOL_COUNTS, hashClientIp, shutdownAnalytics, withAnalytics } from "./services/analytics.js";
 import { checkApiDrift } from "./services/apiDriftCheck.js";
+import { notifyError, notifyServerStarted, notifyServerStopping } from "./services/discord.js";
 import { checkGitBookHealth, fetchGitBookTools } from "./services/gitbookProxy.js";
 import { logger } from "./services/logger.js";
 import { getGitBookToolNames, registerGitBookProxyTools } from "./tools/gitbookProxy.js";
@@ -295,9 +296,18 @@ async function runHTTP(): Promise<void> {
   const port = Number.parseInt(process.env.PORT || "3000");
   app.listen(port, "0.0.0.0", () => {
     logger.info({ port }, `SODAX Builders MCP server running on http://0.0.0.0:${port}`);
+    // #38: announce the server is online to Discord (silent when no webhook set).
+    void notifyServerStarted({
+      version: SERVER_VERSION,
+      transport: "http",
+      port,
+      env: process.env.NODE_ENV || "unset",
+    });
     // Non-blocking: compare live OpenAPI spec against registered MCP tools.
     // Log-only at startup; use `pnpm check:drift` for a CI/CLI-gated run.
-    void checkApiDrift().catch(err => {
+    // notify: true → POST a summary to DISCORD_WEBHOOK_URL when drift is found
+    // and the webhook is set (prod). Empty/unset webhook (staging) = silent.
+    void checkApiDrift({ notify: true }).catch(err => {
       logger.warn({ err }, "⚠️  API drift check threw unexpectedly");
     });
   });
@@ -312,24 +322,42 @@ async function main(): Promise<void> {
   }
 }
 
-main().catch(error => {
-  logger.fatal({ err: error }, "Server error");
-  // Drain the async destination before exit so the fatal line isn't lost
-  // to a half-flushed SonicBoom buffer. Force-exit after 1s if flush stalls
-  // (e.g. transport worker not draining in dev).
-  const force = setTimeout(() => process.exit(1), 1000);
-  logger.flush(() => {
-    clearTimeout(force);
-    process.exit(1);
+/**
+ * Log a fatal error, best-effort notify Discord (#38), drain the log buffer,
+ * then exit 1. The Discord POST is bounded by the notifier's own 5s timeout;
+ * a 1s force-exit guards against a stalled flush (e.g. transport worker not
+ * draining in dev). Re-entrant calls only log — the first call owns the exit.
+ */
+let exiting = false;
+function fatalExit(context: string, error: unknown): void {
+  logger.fatal({ err: error }, context);
+  if (exiting) return;
+  exiting = true;
+  void notifyError(context, error).finally(() => {
+    const force = setTimeout(() => process.exit(1), 1000);
+    logger.flush(() => {
+      clearTimeout(force);
+      process.exit(1);
+    });
   });
-});
+}
 
-// Flush pending PostHog events on shutdown
-process.on("SIGINT", async () => {
+main().catch(error => fatalExit("Server failed to start", error));
+
+// #38: surface unexpected runtime failures to Discord, then exit — preserving
+// Node's default crash semantics for uncaught errors / unhandled rejections.
+process.on("uncaughtException", error => fatalExit("Uncaught exception", error));
+process.on("unhandledRejection", reason => fatalExit("Unhandled promise rejection", reason));
+
+/**
+ * Graceful shutdown: announce to Discord (#38), flush pending PostHog events,
+ * then exit 0. Awaiting the notifier is bounded by its 5s timeout.
+ */
+async function gracefulShutdown(signal: string): Promise<void> {
+  logger.info({ signal }, "Shutting down");
+  await notifyServerStopping(signal);
   await shutdownAnalytics();
   process.exit(0);
-});
-process.on("SIGTERM", async () => {
-  await shutdownAnalytics();
-  process.exit(0);
-});
+}
+process.on("SIGINT", () => void gracefulShutdown("SIGINT"));
+process.on("SIGTERM", () => void gracefulShutdown("SIGTERM"));

--- a/src/index.ts
+++ b/src/index.ts
@@ -355,6 +355,11 @@ process.on("unhandledRejection", reason => fatalExit("Unhandled promise rejectio
  */
 async function gracefulShutdown(signal: string): Promise<void> {
   logger.info({ signal }, "Shutting down");
+  // A redeploy can deliver a second SIGTERM (or SIGINT) while the 5s Discord
+  // notify is still in flight; share fatalExit's `exiting` flag so the first
+  // exit path wins and we don't double-post / double-flush analytics.
+  if (exiting) return;
+  exiting = true;
   await notifyServerStopping(signal);
   await shutdownAnalytics();
   process.exit(0);

--- a/src/scripts/checkDrift.ts
+++ b/src/scripts/checkDrift.ts
@@ -7,5 +7,7 @@
 
 import { checkApiDrift } from "../services/apiDriftCheck.js";
 
-const report = await checkApiDrift();
+// notify: false — the CLI must stay side-effect-free (no Discord POST) on
+// developer machines; the runtime notifier is opt-in at server startup only.
+const report = await checkApiDrift({ notify: false });
 process.exit(report.hasDrift ? 1 : 0);

--- a/src/services/apiDriftCheck.test.ts
+++ b/src/services/apiDriftCheck.test.ts
@@ -156,3 +156,90 @@ describe("checkApiDrift", () => {
     expect(report.summary.paramGaps).toBeGreaterThanOrEqual(1);
   });
 });
+
+describe("checkApiDrift Discord notifier", () => {
+  // An unknown endpoint is the simplest way to force hasDrift: true.
+  const DRIFT_SPEC = { paths: { "/some/unknown/endpoint": { get: {} } } };
+  const originalWebhook = process.env.DISCORD_WEBHOOK_URL;
+
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    mockFetchJson.mockReset();
+    if (originalWebhook === undefined) delete process.env.DISCORD_WEBHOOK_URL;
+    else process.env.DISCORD_WEBHOOK_URL = originalWebhook;
+  });
+
+  it("does not POST when notify is false, even with a webhook set and drift detected", async () => {
+    process.env.DISCORD_WEBHOOK_URL = "https://discord.test/webhook";
+    mockFetchJson.mockResolvedValueOnce(DRIFT_SPEC);
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const report = await checkApiDrift({ notify: false });
+
+    expect(report.hasDrift).toBe(true);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not POST when notify is true but DISCORD_WEBHOOK_URL is unset (staging stays silent)", async () => {
+    delete process.env.DISCORD_WEBHOOK_URL;
+    mockFetchJson.mockResolvedValueOnce(DRIFT_SPEC);
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const report = await checkApiDrift({ notify: true });
+
+    expect(report.hasDrift).toBe(true);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not POST when notify is true and the webhook is set but there is no drift", async () => {
+    process.env.DISCORD_WEBHOOK_URL = "https://discord.test/webhook";
+    mockFetchJson.mockResolvedValueOnce({ paths: {} }); // nothing to gap on → no drift
+    const fetchSpy = vi.fn().mockResolvedValue({ ok: true, status: 204 });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const report = await checkApiDrift({ notify: true });
+
+    expect(report.hasDrift).toBe(false);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("POSTs exactly one drift summary with username 'Drift Watcher' when notify + drift + webhook", async () => {
+    process.env.DISCORD_WEBHOOK_URL = "https://discord.test/webhook";
+    mockFetchJson.mockResolvedValueOnce(DRIFT_SPEC);
+    const fetchSpy = vi.fn().mockResolvedValue({ ok: true, status: 204 });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const report = await checkApiDrift({ notify: true });
+
+    expect(report.hasDrift).toBe(true);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe("https://discord.test/webhook");
+    expect(init.method).toBe("POST");
+    const payload = JSON.parse(init.body as string);
+    expect(payload.username).toBe("Drift Watcher");
+    expect(payload.content).toContain("issue(s) across");
+    expect(payload.content).toContain("Endpoint coverage:");
+    expect(payload.content.length).toBeLessThanOrEqual(1800);
+  });
+
+  it("swallows a network failure on the Discord POST without throwing", async () => {
+    process.env.DISCORD_WEBHOOK_URL = "https://discord.test/webhook";
+    mockFetchJson.mockResolvedValueOnce(DRIFT_SPEC);
+    const fetchSpy = vi.fn().mockRejectedValue(new Error("network down"));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const report = await checkApiDrift({ notify: true });
+
+    // Resolves normally despite the POST failing; the report still reflects drift.
+    expect(report.hasDrift).toBe(true);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/services/apiDriftCheck.ts
+++ b/src/services/apiDriftCheck.ts
@@ -14,10 +14,17 @@
  *
  * The CLI entrypoint (`src/scripts/checkDrift.ts`) exits non-zero on drift;
  * the startup call in `src/index.ts` is fire-and-forget and never throws.
+ *
+ * When called with `{ notify: true }` (prod server startup only) and drift is
+ * detected, a summary is POSTed to `DISCORD_WEBHOOK_URL` if that env var is
+ * non-empty. The CLI path passes `notify: false` so `pnpm check:drift` stays
+ * side-effect-free; an empty/unset webhook (staging) means no network call.
+ * The notifier catches and logs its own errors — it never crashes the server.
  */
 
 import { SODAX_API_BASE_URL } from "../constants.js";
 import { type OpenApiSchema, diff, resolveResponseFields } from "./apiDriftCheckUtils.js";
+import { DISCORD_CONTENT_LIMIT, postToDiscord } from "./discord.js";
 import { fetchJson } from "./http.js";
 import { logger } from "./logger.js";
 
@@ -352,6 +359,15 @@ export interface DriftReport {
   };
 }
 
+export interface DriftCheckOptions {
+  /**
+   * When true and drift is detected, POST a summary to the Discord webhook in
+   * `DISCORD_WEBHOOK_URL` (when non-empty). Default false — the CLI and tests
+   * stay side-effect-free; only the prod server startup opts in.
+   */
+  notify?: boolean;
+}
+
 /** Normalize an OpenAPI path with `{param}` placeholders to `:param` form. */
 function normalizePath(path: string): string {
   return path.replace(/\{([^}]+)\}/g, ":$1");
@@ -361,7 +377,7 @@ function normalizePath(path: string): string {
  * Run all drift sub-checks. Logs to stderr; returns a structured report
  * so callers (CLI vs. startup) can decide how to react.
  */
-export async function checkApiDrift(): Promise<DriftReport> {
+export async function checkApiDrift(options: DriftCheckOptions = {}): Promise<DriftReport> {
   const emptyReport: DriftReport = {
     hasDrift: false,
     summary: { totalEndpoints: 0, endpointGaps: 0, paramGaps: 0, requiredGaps: 0, fieldGaps: 0, uncovered: 0 },
@@ -501,6 +517,15 @@ export async function checkApiDrift(): Promise<DriftReport> {
 
   const issueCount = endpointGaps.length + paramIssues.length + requiredIssues.length + fieldIssues.length;
 
+  const summary: DriftReport["summary"] = {
+    totalEndpoints: total,
+    endpointGaps: endpointGaps.length,
+    paramGaps: paramIssues.length,
+    requiredGaps: requiredIssues.length,
+    fieldGaps: fieldIssues.length,
+    uncovered: uncovered.length,
+  };
+
   if (!hasDrift) {
     logger.info(
       { totalEndpoints: total, uncovered: uncovered.length },
@@ -537,17 +562,17 @@ export async function checkApiDrift(): Promise<DriftReport> {
     for (const key of uncovered) logger.info(`  - ${key}`);
   }
 
-  return {
-    hasDrift,
-    summary: {
-      totalEndpoints: total,
-      endpointGaps: endpointGaps.length,
-      paramGaps: paramIssues.length,
-      requiredGaps: requiredIssues.length,
-      fieldGaps: fieldIssues.length,
-      uncovered: uncovered.length,
-    },
-  };
+  // ── Runtime notification (prod server startup only) ─────────────────────
+  if (options.notify && hasDrift) {
+    const reportText = buildDriftReportText(endpointGaps, paramIssues, requiredIssues, fieldIssues);
+    const delivered = await postToDiscord({
+      username: "Drift Watcher",
+      content: buildDiscordContent(summary, reportText),
+    });
+    if (delivered) logger.info("📣 Drift notifier: posted drift summary to Discord");
+  }
+
+  return { hasDrift, summary };
 }
 
 /**
@@ -560,4 +585,60 @@ function restoreOpenApiPath(normalized: string, paths: OpenApiSpec["paths"]): st
     if (normalizePath(raw) === normalized) return raw;
   }
   return normalized;
+}
+
+/** Render the detailed drift issues as plain text for the Discord fenced block. */
+function buildDriftReportText(
+  endpointGaps: EndpointKey[],
+  paramIssues: DriftIssue[],
+  requiredIssues: DriftIssue[],
+  fieldIssues: DriftIssue[],
+): string {
+  const lines: string[] = [];
+  if (endpointGaps.length > 0) {
+    lines.push(`Endpoint coverage — ${endpointGaps.length} endpoint(s) have no MCP tool:`);
+    for (const key of endpointGaps) lines.push(`  - ${key}`);
+  }
+  if (paramIssues.length > 0) {
+    lines.push(`Param drift — ${paramIssues.length} issue(s):`);
+    for (const issue of paramIssues) lines.push(`  - ${issue.endpoint}: ${issue.detail}`);
+  }
+  if (requiredIssues.length > 0) {
+    lines.push(`Required-flag drift — ${requiredIssues.length} issue(s):`);
+    for (const issue of requiredIssues) lines.push(`  - ${issue.endpoint}: ${issue.detail}`);
+  }
+  if (fieldIssues.length > 0) {
+    lines.push(`Response-field drift — ${fieldIssues.length} issue(s):`);
+    for (const issue of fieldIssues) lines.push(`  - ${issue.endpoint}: ${issue.detail}`);
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Compose the Discord message: a short summary + per-sub-check breakdown,
+ * then the full report inside a fenced block. The report body is truncated so
+ * the whole payload stays within `DISCORD_CONTENT_LIMIT`.
+ */
+function buildDiscordContent(summary: DriftReport["summary"], reportText: string): string {
+  const issueCount = summary.endpointGaps + summary.paramGaps + summary.requiredGaps + summary.fieldGaps;
+  const header = [
+    "**⚠️ API Drift Detected**",
+    `${issueCount} issue(s) across ${summary.totalEndpoints} endpoint(s)`,
+    "",
+    `• Endpoint coverage: ${summary.endpointGaps}`,
+    `• Param drift: ${summary.paramGaps}`,
+    `• Required-flag drift: ${summary.requiredGaps}`,
+    `• Response-field drift: ${summary.fieldGaps}`,
+  ].join("\n");
+
+  const fenceOpen = "\n```\n";
+  const fenceClose = "\n```";
+  const truncationMarker = "\n… (report truncated)";
+  const budget = DISCORD_CONTENT_LIMIT - header.length - fenceOpen.length - fenceClose.length;
+
+  let body = reportText;
+  if (body.length > budget) {
+    body = `${body.slice(0, Math.max(0, budget - truncationMarker.length))}${truncationMarker}`;
+  }
+  return `${header}${fenceOpen}${body}${fenceClose}`;
 }

--- a/src/services/discord.test.ts
+++ b/src/services/discord.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { isDiscordConfigured, notifyError, notifyServerStarted, postToDiscord } from "./discord.js";
+
+const WEBHOOK = "https://discord.test/webhook";
+const originalWebhook = process.env.DISCORD_WEBHOOK_URL;
+
+function stubFetch(impl?: () => unknown) {
+  const spy = vi.fn(impl ?? (() => Promise.resolve({ ok: true, status: 204 })));
+  vi.stubGlobal("fetch", spy);
+  return spy;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  if (originalWebhook === undefined) delete process.env.DISCORD_WEBHOOK_URL;
+  else process.env.DISCORD_WEBHOOK_URL = originalWebhook;
+});
+
+describe("isDiscordConfigured", () => {
+  it("is false when DISCORD_WEBHOOK_URL is unset or blank", () => {
+    delete process.env.DISCORD_WEBHOOK_URL;
+    expect(isDiscordConfigured()).toBe(false);
+    process.env.DISCORD_WEBHOOK_URL = "   ";
+    expect(isDiscordConfigured()).toBe(false);
+  });
+
+  it("is true when DISCORD_WEBHOOK_URL is non-empty", () => {
+    process.env.DISCORD_WEBHOOK_URL = WEBHOOK;
+    expect(isDiscordConfigured()).toBe(true);
+  });
+});
+
+describe("postToDiscord", () => {
+  it("does not call fetch and returns false when no webhook is configured", async () => {
+    delete process.env.DISCORD_WEBHOOK_URL;
+    const fetchSpy = stubFetch();
+    const ok = await postToDiscord({ content: "hi" });
+    expect(ok).toBe(false);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("POSTs to the webhook with the default username and returns true on 2xx", async () => {
+    process.env.DISCORD_WEBHOOK_URL = WEBHOOK;
+    const fetchSpy = stubFetch();
+    const ok = await postToDiscord({ content: "hello" });
+    expect(ok).toBe(true);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe(WEBHOOK);
+    expect(init.method).toBe("POST");
+    const payload = JSON.parse(init.body as string);
+    expect(payload.username).toBe("SODAX MCP Server");
+    expect(payload.content).toBe("hello");
+  });
+
+  it("lets the caller override the username (e.g. the drift notifier)", async () => {
+    process.env.DISCORD_WEBHOOK_URL = WEBHOOK;
+    const fetchSpy = stubFetch();
+    await postToDiscord({ username: "Drift Watcher", content: "x" });
+    const payload = JSON.parse(fetchSpy.mock.calls[0][1].body as string);
+    expect(payload.username).toBe("Drift Watcher");
+  });
+
+  it("returns false on a non-2xx response", async () => {
+    process.env.DISCORD_WEBHOOK_URL = WEBHOOK;
+    stubFetch(() => Promise.resolve({ ok: false, status: 404 }));
+    expect(await postToDiscord({ content: "x" })).toBe(false);
+  });
+
+  it("swallows a network error and returns false (never throws)", async () => {
+    process.env.DISCORD_WEBHOOK_URL = WEBHOOK;
+    stubFetch(() => Promise.reject(new Error("network down")));
+    await expect(postToDiscord({ content: "x" })).resolves.toBe(false);
+  });
+});
+
+describe("notifyServerStarted", () => {
+  it("posts a green 'Server started' embed with version/env/transport/port", async () => {
+    process.env.DISCORD_WEBHOOK_URL = WEBHOOK;
+    const fetchSpy = stubFetch();
+    await notifyServerStarted({ version: "1.2.3", transport: "http", env: "production", port: 3000 });
+    const payload = JSON.parse(fetchSpy.mock.calls[0][1].body as string);
+    const embed = payload.embeds[0];
+    expect(embed.title).toContain("Server started");
+    expect(embed.color).toBe(0x2ecc71);
+    const fieldValues = embed.fields.map((f: { value: string }) => f.value);
+    expect(fieldValues).toEqual(expect.arrayContaining(["1.2.3", "production", "http", "3000"]));
+  });
+
+  it("is silent when no webhook is configured", async () => {
+    delete process.env.DISCORD_WEBHOOK_URL;
+    const fetchSpy = stubFetch();
+    await notifyServerStarted({ version: "1.2.3", transport: "http", env: "production" });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("notifyError", () => {
+  it("posts a red embed with the error message and a fenced stack block", async () => {
+    process.env.DISCORD_WEBHOOK_URL = WEBHOOK;
+    const fetchSpy = stubFetch();
+    await notifyError("Uncaught exception", new Error("boom"));
+    const payload = JSON.parse(fetchSpy.mock.calls[0][1].body as string);
+    const embed = payload.embeds[0];
+    expect(embed.title).toContain("Uncaught exception");
+    expect(embed.color).toBe(0xe74c3c);
+    expect(embed.description).toContain("boom");
+    expect(payload.content).toContain("```");
+  });
+});

--- a/src/services/discord.ts
+++ b/src/services/discord.ts
@@ -44,9 +44,15 @@ export function isDiscordConfigured(): boolean {
   return Boolean(process.env.DISCORD_WEBHOOK_URL?.trim());
 }
 
-/** Truncate `text` to at most `max` chars, adding an ellipsis when cut. */
+/**
+ * Truncate `text` to at most `max` characters, adding an ellipsis when cut.
+ * Splits on code points (via `Array.from`) so a multi-byte emoji is never cut
+ * mid-surrogate-pair, which would otherwise leak a lone surrogate (rendered as
+ * `�`) into the Discord payload.
+ */
 function truncate(text: string, max: number): string {
-  return text.length > max ? `${text.slice(0, max - 1)}…` : text;
+  const chars = Array.from(text);
+  return chars.length > max ? `${chars.slice(0, max - 1).join("")}…` : text;
 }
 
 /**

--- a/src/services/discord.ts
+++ b/src/services/discord.ts
@@ -1,0 +1,128 @@
+/**
+ * Discord webhook notifier.
+ *
+ * A single entry point for posting to `DISCORD_WEBHOOK_URL` — used by the API
+ * drift check (issue #16) and for server status + significant-error alerts
+ * (issue #38).
+ *
+ * Every send is gated on `DISCORD_WEBHOOK_URL` being non-empty (so staging /
+ * local stay silent), uses a 5s timeout, and swallows its own errors. A
+ * notification must NEVER crash or meaningfully block the server, so callers
+ * fire-and-forget (or await the bounded promise on shutdown / crash paths).
+ */
+
+import { logger } from "./logger.js";
+
+const DISCORD_TIMEOUT_MS = 5000;
+const DISCORD_USERNAME = "SODAX MCP Server";
+
+/** Discord caps message `content` at 2000 chars; stay under 1800 for headroom. */
+export const DISCORD_CONTENT_LIMIT = 1800;
+
+/** Embed accent colors (decimal RGB, as Discord expects). */
+const COLOR = {
+  green: 0x2ecc71,
+  red: 0xe74c3c,
+} as const;
+
+interface DiscordEmbed {
+  title?: string;
+  description?: string;
+  color?: number;
+  fields?: { name: string; value: string; inline?: boolean }[];
+  timestamp?: string;
+}
+
+interface DiscordMessage {
+  username?: string;
+  content?: string;
+  embeds?: DiscordEmbed[];
+}
+
+/** True when a webhook URL is configured (non-empty after trim). */
+export function isDiscordConfigured(): boolean {
+  return Boolean(process.env.DISCORD_WEBHOOK_URL?.trim());
+}
+
+/** Truncate `text` to at most `max` chars, adding an ellipsis when cut. */
+function truncate(text: string, max: number): string {
+  return text.length > max ? `${text.slice(0, max - 1)}…` : text;
+}
+
+/**
+ * POST a message to the Discord webhook. Returns true on 2xx delivery, false
+ * otherwise (including when no webhook is configured). Never throws.
+ */
+export async function postToDiscord(message: DiscordMessage): Promise<boolean> {
+  const webhookUrl = process.env.DISCORD_WEBHOOK_URL?.trim();
+  if (!webhookUrl) return false;
+
+  try {
+    const response = await fetch(webhookUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ username: DISCORD_USERNAME, ...message }),
+      signal: AbortSignal.timeout(DISCORD_TIMEOUT_MS),
+    });
+    if (!response.ok) {
+      logger.warn({ status: response.status }, "⚠️  Discord notifier: webhook returned non-2xx");
+      return false;
+    }
+    return true;
+  } catch (err) {
+    logger.warn({ err }, "⚠️  Discord notifier: POST failed (swallowed)");
+    return false;
+  }
+}
+
+/** Notify that the server has come online. */
+export async function notifyServerStarted(info: {
+  version: string;
+  transport: string;
+  env: string;
+  port?: number;
+}): Promise<void> {
+  const fields = [
+    { name: "Version", value: info.version, inline: true },
+    { name: "Environment", value: info.env, inline: true },
+    { name: "Transport", value: info.transport, inline: true },
+  ];
+  if (info.port !== undefined) fields.push({ name: "Port", value: String(info.port), inline: true });
+
+  await postToDiscord({
+    embeds: [{ title: "🟢 Server started", color: COLOR.green, fields, timestamp: new Date().toISOString() }],
+  });
+}
+
+/** Notify that the server is shutting down (e.g. SIGTERM on a redeploy). */
+export async function notifyServerStopping(signal: string): Promise<void> {
+  await postToDiscord({
+    embeds: [
+      {
+        title: "🔴 Server shutting down",
+        description: `Received \`${signal}\``,
+        color: COLOR.red,
+        timestamp: new Date().toISOString(),
+      },
+    ],
+  });
+}
+
+/** Notify a significant / unexpected error, with the stack in a fenced block. */
+export async function notifyError(context: string, error: unknown): Promise<void> {
+  const detail =
+    error instanceof Error ? `${error.name}: ${error.message}` : typeof error === "string" ? error : String(error);
+  const stack = error instanceof Error && error.stack ? error.stack : "";
+
+  await postToDiscord({
+    content: stack ? `\`\`\`\n${truncate(stack, DISCORD_CONTENT_LIMIT - 10)}\n\`\`\`` : undefined,
+    embeds: [
+      {
+        title: truncate(`🚨 ${context}`, 240),
+        description: truncate(detail, 1000),
+        color: COLOR.red,
+        timestamp: new Date().toISOString(),
+      },
+    ],
+  });
+}


### PR DESCRIPTION
## Summary

Adds Discord webhook alerting, the API drift-check CI workflow, Docker-build CI validation, and local `.env` loading. Closes #16, #38, and #54.

## #16 — Drift-check CI + runtime drift notifier
- New `.github/workflows/drift-check.yml`: runs `pnpm check:drift` on PRs, pushes to `development`/`master`, a daily 09:00 UTC cron, and manual dispatch (5-min timeout, no secrets).
- `checkApiDrift({ notify })`: on drift, POSTs a summary to `DISCORD_WEBHOOK_URL` (when set). Server startup opts in; the `pnpm check:drift` CLI stays side-effect-free.

## #38 — Discord alerts for server status + significant errors
- New `src/services/discord.ts`: single webhook entry point — gated on `DISCORD_WEBHOOK_URL`, 5s timeout, errors swallowed (a notification never crashes the server).
- **Server status**: `🟢 Server started` (on listen) and `🔴 Server shutting down` (on SIGTERM/SIGINT).
- **Significant errors**: uncaught exceptions, unhandled rejections, and boot failures → red embed + stack, then exit.
- The drift notifier was refactored to reuse the shared service.

## #54 — Docker build in CI
- New `docker-build` job in `ci.yml` builds the same Dockerfile Coolify deploys (both `builder` and final prod stage), with GitHub Actions cache and no push.
- Catches prod-install / image regressions in CI instead of at deploy time. Especially relevant here since this PR bumps the Docker base to Node 22.

## `.env` loading + Docker
- `dev` / `start` / `check:drift` pass `--env-file-if-exists=.env` — loads a local `.env` when present, with no crash when absent. The app reads `process.env` directly (no dotenv), so this is what makes a local `.env` actually load.
- Requires Node ≥ 22.9.0 (the flag's floor): Docker (both stages) and nixpacks bumped to Node 22; `engines` set to `>=22.9.0`. CI already runs Node 22.
- New `.dockerignore` keeps a real `.env` out of image layers.
- `docker-compose.yml`: default `PORT` to 3000 and mark `.env` optional, so `docker compose up` works with zero config.

## Behavior notes
- Empty/unset `DISCORD_WEBHOOK_URL` = silent (staging/local). The webhook lives on the prod deployment host (Coolify), not in the repo or in GitHub secrets.
- The error handlers notify then exit, preserving Node's default crash semantics.
- Status/error messages post as `SODAX MCP Server`; drift posts as `Drift Watcher`.

## Testing
- `pnpm checkTs`, `pnpm lint`, `pnpm test` (48 tests, incl. new `discord.test.ts`), and `pnpm build` all green.
- Verified live: `.env` auto-load via `pnpm dev`; drift notifier posts on a synthetic drift; server start/stop embeds accepted by Discord; missing-`.env` and refused-webhook paths swallow cleanly without crashing; `docker compose up` builds on Node 22 and serves healthy.

## Follow-ups (out of scope)
- Set `DISCORD_WEBHOOK_URL` on the prod Coolify deployment; leave it unset on staging.
- Branch-protection gating on the drift-check / docker-build checks (repo-admin action).
