### PR TITLE
feat: add sodax_get_volume_stats tool (clears /solver/volume/stats drift)

### DIFF
--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -37,6 +37,7 @@ const TOOL_GROUPS: Record<string, string> = {
   sodax_get_user_transactions: "api",
   sodax_get_intent: "api",
   sodax_get_volume: "api",
+  sodax_get_volume_stats: "api",
   sodax_get_orderbook: "api",
   sodax_get_solver_intent: "api",
   sodax_get_solver_oracle: "api",

--- a/src/services/apiDriftCheck.ts
+++ b/src/services/apiDriftCheck.ts
@@ -214,6 +214,12 @@ const TOOL_CONTRACT: Record<EndpointKey, ToolContract> = {
     requiredParams: [],
     responseFields: ["items", "nextCursor", "hasMore"],
   },
+  "GET /solver/volume/stats": {
+    tool: "sodax_get_volume_stats",
+    params: [],
+    requiredParams: [],
+    responseFields: ["filledCount"],
+  },
   "GET /solver/intents/:intentHash": {
     tool: "sodax_get_solver_intent",
     params: ["intentHash", "includeAll"],

--- a/src/services/sodaxApi.test.ts
+++ b/src/services/sodaxApi.test.ts
@@ -83,3 +83,36 @@ describe("getSwapTokens", () => {
     expect(result).toEqual([{ symbol: "FALLBACK", chainId: "data" }]);
   });
 });
+
+describe("getVolumeStats", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches /solver/volume/stats and returns the filledCount payload", async () => {
+    vi.resetModules();
+    const mod = await import("./sodaxApi.js");
+    const http = await import("./http.js");
+    const mockFetchJson = vi.mocked(http.fetchJson);
+    mockFetchJson.mockResolvedValueOnce({ filledCount: 12345 });
+
+    const result = await mod.getVolumeStats();
+
+    expect(result).toEqual({ filledCount: 12345 });
+    expect(mockFetchJson).toHaveBeenCalledWith(expect.stringContaining("/solver/volume/stats"));
+  });
+
+  it("serves a cached value on the second call without re-fetching", async () => {
+    vi.resetModules();
+    const mod = await import("./sodaxApi.js");
+    const http = await import("./http.js");
+    const mockFetchJson = vi.mocked(http.fetchJson);
+    mockFetchJson.mockResolvedValueOnce({ filledCount: 7 });
+
+    await mod.getVolumeStats();
+    const second = await mod.getVolumeStats();
+
+    expect(second).toEqual({ filledCount: 7 });
+    expect(mockFetchJson).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/services/sodaxApi.ts
+++ b/src/services/sodaxApi.ts
@@ -16,6 +16,7 @@ import type {
   Transaction,
   UserPosition,
   VolumeData,
+  VolumeStats,
 } from "../types.js";
 import { fetchJson, fetchJsonOrNull } from "./http.js";
 import { logger } from "./logger.js";
@@ -198,6 +199,25 @@ export async function getVolume(options: {
   } catch (error) {
     logger.error({ err: error }, "Failed to fetch volume");
     throw new Error("Failed to fetch volume data from SODAX API");
+  }
+}
+
+/**
+ * Get aggregate solver volume stats (approximate filled-intent record count).
+ * Backed by a collection-metadata read upstream and cached 60s server-side.
+ */
+export async function getVolumeStats(): Promise<VolumeStats> {
+  const cacheKey = "volume-stats";
+  const cached = getCached<VolumeStats>(cacheKey);
+  if (cached) return cached;
+
+  try {
+    const stats = await fetchJson<VolumeStats>(apiUrl("/solver/volume/stats"));
+    setCache(cacheKey, stats);
+    return stats;
+  } catch (error) {
+    logger.error({ err: error }, "Failed to fetch volume stats");
+    throw new Error("Failed to fetch volume stats from SODAX API");
   }
 }
 

--- a/src/tools/sodaxApi.ts
+++ b/src/tools/sodaxApi.ts
@@ -2,7 +2,7 @@
  * SODAX API Tools
  *
  * MCP tool definitions for accessing live SODAX API data.
- * Provides 27 tools for developers and integration partners.
+ * Provides 28 tools for developers and integration partners.
  */
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -38,6 +38,7 @@ import {
   getUserPosition,
   getUserTransactions,
   getVolume,
+  getVolumeStats,
 } from "../services/sodaxApi.js";
 import { clearSolverCache, getSolverCacheStats } from "../services/solver.js";
 import { ResponseFormat } from "../types.js";
@@ -292,6 +293,38 @@ export function registerSodaxApiTools(server: McpServer): void {
             {
               type: "text",
               text: header + formatResponse(volume.items, format) + pagination,
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [{ type: "text", text: `Error: ${error instanceof Error ? error.message : "Unknown error"}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  // Tool 5b: Get Volume Stats (aggregate filled-intent count)
+  server.tool(
+    "sodax_get_volume_stats",
+    "Get aggregate solver volume stats: the approximate total number of filled-intent records (fill documents, not distinct intents). Cached ~60s upstream.",
+    {
+      format: z
+        .nativeEnum(ResponseFormat)
+        .optional()
+        .default(ResponseFormat.MARKDOWN)
+        .describe("Response format: 'json' for raw data or 'markdown' for formatted text"),
+    },
+    READ_ONLY,
+    async ({ format }) => {
+      try {
+        const stats = await getVolumeStats();
+        return {
+          content: [
+            {
+              type: "text",
+              text: `## SODAX Solver Volume Stats\n\n${formatResponse(stats, format)}`,
             },
           ],
         };

--- a/src/types.ts
+++ b/src/types.ts
@@ -96,6 +96,14 @@ export interface VolumeData {
 }
 
 /**
+ * Aggregate solver volume stats. `filledCount` is the approximate total number
+ * of filled-intent records (fill documents, not distinct intents).
+ */
+export interface VolumeStats {
+  filledCount: number;
+}
+
+/**
  * Orderbook entry for limit orders
  */
 export interface OrderbookEntry {


### PR DESCRIPTION
## Why
The API drift check flagged `GET /solver/volume/stats` as an uncovered endpoint — upstream added it (aggregate filled-intent count). This surfaced as the **authoritative push-event drift failure** on the development→master promotion (#61). Resolving by **exposing** it as a tool (per the repo's `IGNORED_PATHS` stance: "all API endpoints should be exposed").

## Changes
- **service** `getVolumeStats()` → `{ filledCount }`, 60s-cached (`src/services/sodaxApi.ts`)
- **tool** `sodax_get_volume_stats` (json/markdown), tool count 27→28 (`src/tools/sodaxApi.ts`)
- **analytics** mapped to the `api` group so `STATIC_TOOL_COUNTS` / `/health` stay in sync
- **drift contract** entry with `responseFields: ["filledCount"]` (`src/services/apiDriftCheck.ts`)
- **types** `VolumeStats` interface
- **tests** service fetch + cache coverage (50 tests pass)

## Verification
`checkTs`, `lint`, all 50 tests pass. `pnpm check:drift` against the live API now exits **0**.

Once merged, #61 (development→master) updates automatically and its authoritative drift run goes green.