### PR TITLE
feat: clarify solver quote token guidance and add error hints

### DIFF
--- a/src/tools/solverRelay.test.ts
+++ b/src/tools/solverRelay.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { quoteErrorHint } from "./solverRelay.js";
 
 describe("quoteErrorHint", () => {
-  it("hints to use a chainId-146 hub address when a token is not compatible", () => {
+  it("steers a not-compatible token toward canonical bridged *_ASSET hub tokens", () => {
     // Real upstream shape: `{ detail: { message: "One of the following tokens
     // is not compatible with the quote service: 0x…, 0x…" } }`, surfaced by the
     // http/service layers as part of the thrown Error message.
@@ -15,6 +15,10 @@ describe("quoteErrorHint", () => {
     expect(hint).not.toBeNull();
     expect(hint).toContain("chainId 146");
     expect(hint).toContain("sodax_get_solver_oracle");
+    // Must recommend canonical bridged *_ASSET tokens, not just "any chainId 146"
+    // (per issue #64: ~half of chainId-146 oracle entries are non-quotable).
+    expect(hint).toContain("*_ASSET");
+    expect(hint).toContain("Not every chainId-146 oracle entry is quotable");
   });
 
   it("hints that 'no path' is liquidity/amount-dependent and recoverable", () => {

--- a/src/tools/solverRelay.test.ts
+++ b/src/tools/solverRelay.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { quoteErrorHint } from "./solverRelay.js";
+
+describe("quoteErrorHint", () => {
+  it("hints to use a chainId-146 hub address when a token is not compatible", () => {
+    // Real upstream shape: `{ detail: { message: "One of the following tokens
+    // is not compatible with the quote service: 0x…, 0x…" } }`, surfaced by the
+    // http/service layers as part of the thrown Error message.
+    const message =
+      "Failed to fetch solver quote: HTTP 400 for https://api.sodax.com/v1/intent/quote - " +
+      "One of the following tokens is not compatible with the quote service: 0xabc, 0xdef";
+
+    const hint = quoteErrorHint(message);
+
+    expect(hint).not.toBeNull();
+    expect(hint).toContain("chainId 146");
+    expect(hint).toContain("sodax_get_solver_oracle");
+  });
+
+  it("hints that 'no path' is liquidity/amount-dependent and recoverable", () => {
+    const message =
+      "Failed to fetch solver quote: HTTP 400 for https://api.sodax.com/v1/intent/quote - " +
+      "No path was found between 0xeb0393893b5bf98a50073d6740738b08e575058b and 0xaeafa26e43f46cd83efe89b1e57c858eb5685a24";
+
+    const hint = quoteErrorHint(message);
+
+    expect(hint).not.toBeNull();
+    expect(hint).toContain("smaller amount");
+    expect(hint).toContain("liquid");
+  });
+
+  it("is case-insensitive (matches regardless of upstream casing)", () => {
+    expect(quoteErrorHint("NOT COMPATIBLE WITH THE QUOTE SERVICE")).not.toBeNull();
+    expect(quoteErrorHint("NO PATH WAS FOUND between a and b")).not.toBeNull();
+  });
+
+  it("returns null for unrelated errors so no misleading hint is appended", () => {
+    expect(quoteErrorHint("Failed to fetch solver quote: HTTP 503 for … - upstream unavailable")).toBeNull();
+    expect(quoteErrorHint("The operation was aborted due to timeout")).toBeNull();
+    expect(quoteErrorHint("Unknown error")).toBeNull();
+  });
+});

--- a/src/tools/solverRelay.test.ts
+++ b/src/tools/solverRelay.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it } from "vitest";
 import { quoteErrorHint } from "./solverRelay.js";
 
 describe("quoteErrorHint", () => {
-  it("steers a not-compatible token toward canonical bridged *_ASSET hub tokens", () => {
+  it("hints to use a chainId-146 hub address when a token is not compatible", () => {
     // Real upstream shape: `{ detail: { message: "One of the following tokens
     // is not compatible with the quote service: 0x…, 0x…" } }`, surfaced by the
-    // http/service layers as part of the thrown Error message.
+    // http/service layers as part of the thrown Error message. Verified against
+    // the live API: this error fires only for spoke-chain / non-chainId-146
+    // addresses — every chainId-146 oracle address passes the compatibility check.
     const message =
       "Failed to fetch solver quote: HTTP 400 for https://api.sodax.com/v1/intent/quote - " +
       "One of the following tokens is not compatible with the quote service: 0xabc, 0xdef";
@@ -15,10 +17,6 @@ describe("quoteErrorHint", () => {
     expect(hint).not.toBeNull();
     expect(hint).toContain("chainId 146");
     expect(hint).toContain("sodax_get_solver_oracle");
-    // Must recommend canonical bridged *_ASSET tokens, not just "any chainId 146"
-    // (per issue #64: ~half of chainId-146 oracle entries are non-quotable).
-    expect(hint).toContain("*_ASSET");
-    expect(hint).toContain("Not every chainId-146 oracle entry is quotable");
   });
 
   it("hints that 'no path' is liquidity/amount-dependent and recoverable", () => {

--- a/src/tools/solverRelay.test.ts
+++ b/src/tools/solverRelay.test.ts
@@ -17,6 +17,9 @@ describe("quoteErrorHint", () => {
     expect(hint).not.toBeNull();
     expect(hint).toContain("chainId 146");
     expect(hint).toContain("sodax_get_solver_oracle");
+    // Steer to the reliable set — chainId 146 alone doesn't guarantee a route,
+    // so the hint must not regress to overly-broad "any chainId 146" guidance.
+    expect(hint).toContain("*_ASSET");
   });
 
   it("hints that 'no path' is liquidity/amount-dependent and recoverable", () => {

--- a/src/tools/solverRelay.ts
+++ b/src/tools/solverRelay.ts
@@ -37,8 +37,11 @@ const RELAY_SUBMIT: ToolAnnotations = {
  *
  * The solver returns two distinct HTTP-400 failures (both already naming the
  * two addresses), and the right next step differs:
- *  - "not compatible with the quote service" → one address isn't a recognized
- *    hub asset (a spoke-chain or otherwise-wrong address was passed).
+ *  - "not compatible with the quote service" → one address isn't in the
+ *    solver's quotable set. Not every chainId-146 oracle entry is quotable:
+ *    wrapped/derivative/money-market entries (e.g. WBTC, waLoc*, soda*) are
+ *    priced by the oracle but rejected here, as are spoke-chain addresses.
+ *    Only canonical bridged *_ASSET hub tokens and major stablecoins are safe.
  *  - "No path was found between …" → both tokens are valid hub assets but the
  *    solver couldn't route this pair *for this amount*; routing is liquidity-
  *    dependent, so a smaller amount or a more liquid counterparty often works.
@@ -49,10 +52,10 @@ const RELAY_SUBMIT: ToolAnnotations = {
 export function quoteErrorHint(message: string): string | null {
   const m = message.toLowerCase();
   if (m.includes("not compatible with the quote service")) {
-    return "Hint: one of the addresses isn't a recognized hub asset. tokenSrc/tokenDst must be hub-chain (Sonic, chainId 146) addresses — look one up via sodax_get_solver_oracle with chainId='146'. Spoke-chain and other non-hub addresses are rejected here.";
+    return "Hint: one of the addresses isn't in the solver's quotable set. Not every chainId-146 oracle entry is quotable — wrapped/derivative/money-market entries (e.g. WBTC, waLoc*, soda*) are priced by sodax_get_solver_oracle but rejected here, as are spoke-chain addresses. Prefer a canonical bridged *_ASSET hub token (e.g. BTC_BTC_ASSET, ETH_ASSET) or a major stablecoin like SONIC_USDC_ASSET — all chainId 146.";
   }
   if (m.includes("no path was found")) {
-    return "Hint: both tokens are valid hub assets, but the solver couldn't route this pair for this amount. Routing is liquidity-dependent — retry with a smaller amount, or pick a more liquid counterparty (a canonical bridged *_ASSET hub token, or a major stablecoin like SONIC_USDC_ASSET). Wrapped/derivative entries (e.g. WBTC, waLoc*, soda*) are oracle-priced but frequently have no route.";
+    return "Hint: both tokens are quotable hub assets, but the solver couldn't route this pair for this amount. Routing is liquidity-dependent — retry with a smaller amount, or pick a more liquid counterparty (a canonical bridged *_ASSET hub token, or a major stablecoin like SONIC_USDC_ASSET).";
   }
   return null;
 }
@@ -61,7 +64,7 @@ export function registerSolverRelayTools(server: McpServer): void {
   // ── Solver: oracle ──────────────────────────────────────────────────
   server.tool(
     "sodax_get_solver_oracle",
-    "Get the solver's oracle USD prices per (chain, token). For quoting with sodax_get_solver_quote, filter chainId='146': every chainId-146 address listed here is accepted by the quote service (spoke-chain addresses are not). Caveat: being listed (priced) does NOT guarantee a swap route — canonical bridged *_ASSET hub tokens and major stablecoins route most reliably, while wrapped/derivative/money-market entries (e.g. WBTC, waLoc*, soda*, lsoda*, xSODA) are priced but frequently have no route, and routability is also liquidity/amount-dependent. Also useful for sanity-checking quote amounts against the USD prices the solver uses.",
+    "Get the solver's oracle USD prices per (chain, token). For quoting with sodax_get_solver_quote, filter chainId='146' — but note that NOT every chainId-146 entry is quotable: only canonical bridged *_ASSET hub tokens and major stablecoins are accepted by the quote service. Wrapped/derivative/money-market entries (e.g. WBTC, waLoc*, soda*, lsoda*, xSODA) are priced here but rejected with 'not compatible with the quote service' (as are spoke-chain addresses). Even among quotable tokens, a specific pair/amount can still return 'No path was found' (routing is liquidity/amount-dependent). Also useful for sanity-checking quote amounts against the USD prices the solver uses.",
     {
       chainId: z
         .string()
@@ -109,12 +112,12 @@ export function registerSolverRelayTools(server: McpServer): void {
   // ── Solver: quote ───────────────────────────────────────────────────
   server.tool(
     "sodax_get_solver_quote",
-    "Get a swap quote from the SODAX solver. tokenSrc/tokenDst MUST be hub-chain (Sonic, chainId 146) asset addresses — look them up with sodax_get_solver_oracle (chainId='146'). Working example: tokenSrc='0xeb0393893b5bf98a50073d6740738b08e575058b' (BTC_BTC_ASSET) → tokenDst='0xaeafa26e43f46cd83efe89b1e57c858eb5685a24' (ETH_ASSET), amount='99800', quoteType='exact_input' returns a quoted_amount. exact_input quotes the destination amount you'd receive; exact_output quotes the source amount you'd need. There are two distinct HTTP-400 failures, both naming the two addresses: (1) 'not compatible with the quote service' = an address isn't a recognized hub asset (a spoke-chain or wrong address was passed) → use a chainId-146 address from sodax_get_solver_oracle; (2) 'No path was found between X and Y' = both tokens are valid hub assets but the solver couldn't route this pair for this amount → routing is liquidity-dependent, so retry with a smaller amount or a more liquid counterparty (a canonical bridged *_ASSET token, or a major stablecoin like SONIC_USDC_ASSET). Wrapped/derivative/money-market entries (e.g. WBTC, waLoc*, soda*) are oracle-priced but frequently have no route — prefer canonical bridged *_ASSET hub tokens.",
+    "Get a swap quote from the SODAX solver. tokenSrc/tokenDst MUST be hub-chain (Sonic, chainId 146) asset addresses — look them up with sodax_get_solver_oracle (chainId='146'). Working example: tokenSrc='0xeb0393893b5bf98a50073d6740738b08e575058b' (BTC_BTC_ASSET) → tokenDst='0xaeafa26e43f46cd83efe89b1e57c858eb5685a24' (ETH_ASSET), amount='99800', quoteType='exact_input' returns a quoted_amount. exact_input quotes the destination amount you'd receive; exact_output quotes the source amount you'd need. There are two distinct HTTP-400 failures, both naming the two addresses: (1) 'not compatible with the quote service' = an address isn't in the solver's quotable set. Not every chainId-146 oracle entry is quotable — wrapped/derivative/money-market entries (e.g. WBTC, waLoc*, soda*) are priced by sodax_get_solver_oracle but rejected here, as are spoke-chain addresses → use a canonical bridged *_ASSET hub token (e.g. BTC_BTC_ASSET, ETH_ASSET) or a major stablecoin like SONIC_USDC_ASSET. (2) 'No path was found between X and Y' = both tokens are quotable hub assets but the solver couldn't route this pair for this amount → routing is liquidity-dependent, so retry with a smaller amount or a more liquid counterparty.",
     {
       tokenSrc: z
         .string()
         .describe(
-          "REQUIRED: Source token address (the token you're spending). Hub-chain (Sonic, chainId 146) asset address from sodax_get_solver_oracle. Prefer canonical bridged *_ASSET tokens (e.g. BTC_BTC_ASSET 0xeb0393893b5bf98a50073d6740738b08e575058b); wrapped/derivative entries like WBTC are priced but often have no route.",
+          "REQUIRED: Source token address (the token you're spending). Hub-chain (Sonic, chainId 146) asset address from sodax_get_solver_oracle. Prefer canonical bridged *_ASSET tokens (e.g. BTC_BTC_ASSET 0xeb0393893b5bf98a50073d6740738b08e575058b); wrapped/derivative entries like WBTC are priced but rejected as 'not compatible'.",
         ),
       tokenDst: z
         .string()

--- a/src/tools/solverRelay.ts
+++ b/src/tools/solverRelay.ts
@@ -36,15 +36,16 @@ const RELAY_SUBMIT: ToolAnnotations = {
  * Map an upstream solver-quote error to an actionable, caller-facing hint.
  *
  * The solver returns two distinct HTTP-400 failures (both already naming the
- * two addresses), and the right next step differs:
- *  - "not compatible with the quote service" → one address isn't in the
- *    solver's quotable set. Not every chainId-146 oracle entry is quotable:
- *    wrapped/derivative/money-market entries (e.g. WBTC, waLoc*, soda*) are
- *    priced by the oracle but rejected here, as are spoke-chain addresses.
- *    Only canonical bridged *_ASSET hub tokens and major stablecoins are safe.
- *  - "No path was found between …" → both tokens are valid hub assets but the
- *    solver couldn't route this pair *for this amount*; routing is liquidity-
- *    dependent, so a smaller amount or a more liquid counterparty often works.
+ * two addresses), and the right next step differs (verified against the live
+ * api.sodax.com quote endpoint):
+ *  - "not compatible with the quote service" → one address isn't a recognized
+ *    hub asset. This fires for spoke-chain (non-chainId-146) or otherwise
+ *    unknown addresses; every chainId-146 oracle address passes this check.
+ *  - "No path was found between …" → both tokens are valid chainId-146 hub
+ *    assets but the solver couldn't route this pair *for this amount*. Routing
+ *    is pair/amount/liquidity-dependent, so a smaller amount or a more liquid
+ *    counterparty often works. Many wrapped/derivative entries (e.g. WBTC,
+ *    waLocBTC, SONIC_SODA_ASSET) are oracle-priced but frequently unroutable.
  *
  * Returns null for any other message so we never bolt a misleading hint onto an
  * unrelated failure (timeouts, 5xx, contract drift, …).
@@ -52,10 +53,10 @@ const RELAY_SUBMIT: ToolAnnotations = {
 export function quoteErrorHint(message: string): string | null {
   const m = message.toLowerCase();
   if (m.includes("not compatible with the quote service")) {
-    return "Hint: one of the addresses isn't in the solver's quotable set. Not every chainId-146 oracle entry is quotable — wrapped/derivative/money-market entries (e.g. WBTC, waLoc*, soda*) are priced by sodax_get_solver_oracle but rejected here, as are spoke-chain addresses. Prefer a canonical bridged *_ASSET hub token (e.g. BTC_BTC_ASSET, ETH_ASSET) or a major stablecoin like SONIC_USDC_ASSET — all chainId 146.";
+    return "Hint: one of the addresses isn't a recognized hub asset. tokenSrc/tokenDst must be hub-chain (Sonic, chainId 146) asset addresses — look one up via sodax_get_solver_oracle with chainId='146'. Spoke-chain and other non-146 addresses are rejected here.";
   }
   if (m.includes("no path was found")) {
-    return "Hint: both tokens are quotable hub assets, but the solver couldn't route this pair for this amount. Routing is liquidity-dependent — retry with a smaller amount, or pick a more liquid counterparty (a canonical bridged *_ASSET hub token, or a major stablecoin like SONIC_USDC_ASSET).";
+    return "Hint: both tokens are valid hub assets, but the solver couldn't route this pair for this amount. Routing is pair/amount/liquidity-dependent — retry with a smaller amount, or pick a more liquid counterparty (a canonical bridged *_ASSET hub token, or a major stablecoin like SONIC_USDC_ASSET). Many wrapped/derivative entries (e.g. WBTC, waLocBTC, SONIC_SODA_ASSET) are oracle-priced but frequently have no route.";
   }
   return null;
 }
@@ -64,7 +65,7 @@ export function registerSolverRelayTools(server: McpServer): void {
   // ── Solver: oracle ──────────────────────────────────────────────────
   server.tool(
     "sodax_get_solver_oracle",
-    "Get the solver's oracle USD prices per (chain, token). For quoting with sodax_get_solver_quote, filter chainId='146' — but note that NOT every chainId-146 entry is quotable: only canonical bridged *_ASSET hub tokens and major stablecoins are accepted by the quote service. Wrapped/derivative/money-market entries (e.g. WBTC, waLoc*, soda*, lsoda*, xSODA) are priced here but rejected with 'not compatible with the quote service' (as are spoke-chain addresses). Even among quotable tokens, a specific pair/amount can still return 'No path was found' (routing is liquidity/amount-dependent). Also useful for sanity-checking quote amounts against the USD prices the solver uses.",
+    "Get the solver's oracle USD prices per (chain, token). For quoting with sodax_get_solver_quote, filter chainId='146': chainId-146 addresses are accepted by the quote service, while spoke-chain (non-146) addresses are rejected with 'not compatible with the quote service'. Caveat: being listed (priced) does NOT guarantee a swap route — canonical bridged *_ASSET hub tokens and major stablecoins route most reliably, while many wrapped/derivative/money-market entries (e.g. WBTC, waLocBTC, SONIC_SODA_ASSET) are priced but frequently return 'No path was found', and routability is pair/amount/liquidity-dependent. Also useful for sanity-checking quote amounts against the USD prices the solver uses.",
     {
       chainId: z
         .string()
@@ -112,12 +113,12 @@ export function registerSolverRelayTools(server: McpServer): void {
   // ── Solver: quote ───────────────────────────────────────────────────
   server.tool(
     "sodax_get_solver_quote",
-    "Get a swap quote from the SODAX solver. tokenSrc/tokenDst MUST be hub-chain (Sonic, chainId 146) asset addresses — look them up with sodax_get_solver_oracle (chainId='146'). Working example: tokenSrc='0xeb0393893b5bf98a50073d6740738b08e575058b' (BTC_BTC_ASSET) → tokenDst='0xaeafa26e43f46cd83efe89b1e57c858eb5685a24' (ETH_ASSET), amount='99800', quoteType='exact_input' returns a quoted_amount. exact_input quotes the destination amount you'd receive; exact_output quotes the source amount you'd need. There are two distinct HTTP-400 failures, both naming the two addresses: (1) 'not compatible with the quote service' = an address isn't in the solver's quotable set. Not every chainId-146 oracle entry is quotable — wrapped/derivative/money-market entries (e.g. WBTC, waLoc*, soda*) are priced by sodax_get_solver_oracle but rejected here, as are spoke-chain addresses → use a canonical bridged *_ASSET hub token (e.g. BTC_BTC_ASSET, ETH_ASSET) or a major stablecoin like SONIC_USDC_ASSET. (2) 'No path was found between X and Y' = both tokens are quotable hub assets but the solver couldn't route this pair for this amount → routing is liquidity-dependent, so retry with a smaller amount or a more liquid counterparty.",
+    "Get a swap quote from the SODAX solver. tokenSrc/tokenDst MUST be hub-chain (Sonic, chainId 146) asset addresses — look them up with sodax_get_solver_oracle (chainId='146'). Working example: tokenSrc='0xeb0393893b5bf98a50073d6740738b08e575058b' (BTC_BTC_ASSET) → tokenDst='0xaeafa26e43f46cd83efe89b1e57c858eb5685a24' (ETH_ASSET), amount='99800', quoteType='exact_input' returns a quoted_amount. exact_input quotes the destination amount you'd receive; exact_output quotes the source amount you'd need. There are two distinct HTTP-400 failures, both naming the two addresses: (1) 'not compatible with the quote service' = an address isn't a recognized hub asset (a spoke-chain or otherwise non-chainId-146 address was passed) → use a chainId-146 address from sodax_get_solver_oracle. (2) 'No path was found between X and Y' = both tokens are valid hub assets but the solver couldn't route this pair for this amount → routing is pair/amount/liquidity-dependent, so retry with a smaller amount or a more liquid counterparty (a canonical bridged *_ASSET token, or a major stablecoin like SONIC_USDC_ASSET). Many wrapped/derivative entries (e.g. WBTC, waLocBTC, SONIC_SODA_ASSET) are oracle-priced but frequently have no route — prefer canonical bridged *_ASSET hub tokens.",
     {
       tokenSrc: z
         .string()
         .describe(
-          "REQUIRED: Source token address (the token you're spending). Hub-chain (Sonic, chainId 146) asset address from sodax_get_solver_oracle. Prefer canonical bridged *_ASSET tokens (e.g. BTC_BTC_ASSET 0xeb0393893b5bf98a50073d6740738b08e575058b); wrapped/derivative entries like WBTC are priced but rejected as 'not compatible'.",
+          "REQUIRED: Source token address (the token you're spending). Hub-chain (Sonic, chainId 146) asset address from sodax_get_solver_oracle. Prefer canonical bridged *_ASSET tokens (e.g. BTC_BTC_ASSET 0xeb0393893b5bf98a50073d6740738b08e575058b); wrapped/derivative entries like WBTC are priced but frequently have no route.",
         ),
       tokenDst: z
         .string()

--- a/src/tools/solverRelay.ts
+++ b/src/tools/solverRelay.ts
@@ -40,7 +40,9 @@ const RELAY_SUBMIT: ToolAnnotations = {
  * api.sodax.com quote endpoint):
  *  - "not compatible with the quote service" → one address isn't a recognized
  *    hub asset. This fires for spoke-chain (non-chainId-146) or otherwise
- *    unknown addresses; every chainId-146 oracle address passes this check.
+ *    unrecognized addresses; a chainId-146 hub asset passes this check (an
+ *    unroutable one fails later with "No path" instead). Passing the check
+ *    doesn't guarantee a route, so steer callers to the reliable set.
  *  - "No path was found between …" → both tokens are valid chainId-146 hub
  *    assets but the solver couldn't route this pair *for this amount*. Routing
  *    is pair/amount/liquidity-dependent, so a smaller amount or a more liquid
@@ -53,7 +55,7 @@ const RELAY_SUBMIT: ToolAnnotations = {
 export function quoteErrorHint(message: string): string | null {
   const m = message.toLowerCase();
   if (m.includes("not compatible with the quote service")) {
-    return "Hint: one of the addresses isn't a recognized hub asset. tokenSrc/tokenDst must be hub-chain (Sonic, chainId 146) asset addresses — look one up via sodax_get_solver_oracle with chainId='146'. Spoke-chain and other non-146 addresses are rejected here.";
+    return "Hint: one of the addresses isn't a recognized hub asset — spoke-chain and other non-146 addresses are rejected here. Use a hub-chain (Sonic, chainId 146) asset address from sodax_get_solver_oracle; for a reliable next pick prefer a canonical bridged *_ASSET hub token (e.g. BTC_BTC_ASSET, ETH_ASSET) or a major stablecoin like SONIC_USDC_ASSET — chainId 146 alone doesn't guarantee a route.";
   }
   if (m.includes("no path was found")) {
     return "Hint: both tokens are valid hub assets, but the solver couldn't route this pair for this amount. Routing is pair/amount/liquidity-dependent — retry with a smaller amount, or pick a more liquid counterparty (a canonical bridged *_ASSET hub token, or a major stablecoin like SONIC_USDC_ASSET). Many wrapped/derivative entries (e.g. WBTC, waLocBTC, SONIC_SODA_ASSET) are oracle-priced but frequently have no route.";
@@ -65,7 +67,7 @@ export function registerSolverRelayTools(server: McpServer): void {
   // ── Solver: oracle ──────────────────────────────────────────────────
   server.tool(
     "sodax_get_solver_oracle",
-    "Get the solver's oracle USD prices per (chain, token). For quoting with sodax_get_solver_quote, filter chainId='146': chainId-146 addresses are accepted by the quote service, while spoke-chain (non-146) addresses are rejected with 'not compatible with the quote service'. Caveat: being listed (priced) does NOT guarantee a swap route — canonical bridged *_ASSET hub tokens and major stablecoins route most reliably, while many wrapped/derivative/money-market entries (e.g. WBTC, waLocBTC, SONIC_SODA_ASSET) are priced but frequently return 'No path was found', and routability is pair/amount/liquidity-dependent. Also useful for sanity-checking quote amounts against the USD prices the solver uses.",
+    "Get the solver's oracle USD prices per (chain, token). For quoting with sodax_get_solver_quote, filter chainId='146': chainId-146 addresses pass the quote service's compatibility check, while spoke-chain (non-146) addresses are rejected with 'not compatible with the quote service'. Caveat: passing that check (being listed/priced) does NOT guarantee a swap route — canonical bridged *_ASSET hub tokens and major stablecoins route most reliably, while many wrapped/derivative/money-market entries (e.g. WBTC, waLocBTC, SONIC_SODA_ASSET) are priced but frequently return 'No path was found', and routability is pair/amount/liquidity-dependent. Also useful for sanity-checking quote amounts against the USD prices the solver uses.",
     {
       chainId: z
         .string()
@@ -113,7 +115,7 @@ export function registerSolverRelayTools(server: McpServer): void {
   // ── Solver: quote ───────────────────────────────────────────────────
   server.tool(
     "sodax_get_solver_quote",
-    "Get a swap quote from the SODAX solver. tokenSrc/tokenDst MUST be hub-chain (Sonic, chainId 146) asset addresses — look them up with sodax_get_solver_oracle (chainId='146'). Working example: tokenSrc='0xeb0393893b5bf98a50073d6740738b08e575058b' (BTC_BTC_ASSET) → tokenDst='0xaeafa26e43f46cd83efe89b1e57c858eb5685a24' (ETH_ASSET), amount='99800', quoteType='exact_input' returns a quoted_amount. exact_input quotes the destination amount you'd receive; exact_output quotes the source amount you'd need. There are two distinct HTTP-400 failures, both naming the two addresses: (1) 'not compatible with the quote service' = an address isn't a recognized hub asset (a spoke-chain or otherwise non-chainId-146 address was passed) → use a chainId-146 address from sodax_get_solver_oracle. (2) 'No path was found between X and Y' = both tokens are valid hub assets but the solver couldn't route this pair for this amount → routing is pair/amount/liquidity-dependent, so retry with a smaller amount or a more liquid counterparty (a canonical bridged *_ASSET token, or a major stablecoin like SONIC_USDC_ASSET). Many wrapped/derivative entries (e.g. WBTC, waLocBTC, SONIC_SODA_ASSET) are oracle-priced but frequently have no route — prefer canonical bridged *_ASSET hub tokens.",
+    "Get a swap quote from the SODAX solver. tokenSrc/tokenDst MUST be hub-chain (Sonic, chainId 146) asset addresses — look them up with sodax_get_solver_oracle (chainId='146'). Working example: tokenSrc='0xeb0393893b5bf98a50073d6740738b08e575058b' (BTC_BTC_ASSET) → tokenDst='0xaeafa26e43f46cd83efe89b1e57c858eb5685a24' (ETH_ASSET), amount='99800', quoteType='exact_input' returns a quoted_amount. exact_input quotes the destination amount you'd receive; exact_output quotes the source amount you'd need. There are two distinct HTTP-400 failures, both naming the two addresses: (1) 'not compatible with the quote service' = an address isn't a recognized hub asset (a spoke-chain or otherwise non-chainId-146 address was passed) → use a chainId-146 address from sodax_get_solver_oracle, and for a reliable pick prefer a canonical bridged *_ASSET hub token or major stablecoin (chainId 146 alone doesn't guarantee a route). (2) 'No path was found between X and Y' = both tokens are valid hub assets but the solver couldn't route this pair for this amount → routing is pair/amount/liquidity-dependent, so retry with a smaller amount or a more liquid counterparty (a canonical bridged *_ASSET token, or a major stablecoin like SONIC_USDC_ASSET). Many wrapped/derivative entries (e.g. WBTC, waLocBTC, SONIC_SODA_ASSET) are oracle-priced but frequently have no route — prefer canonical bridged *_ASSET hub tokens.",
     {
       tokenSrc: z
         .string()

--- a/src/tools/solverRelay.ts
+++ b/src/tools/solverRelay.ts
@@ -32,11 +32,36 @@ const RELAY_SUBMIT: ToolAnnotations = {
   openWorldHint: true,
 };
 
+/**
+ * Map an upstream solver-quote error to an actionable, caller-facing hint.
+ *
+ * The solver returns two distinct HTTP-400 failures (both already naming the
+ * two addresses), and the right next step differs:
+ *  - "not compatible with the quote service" → one address isn't a recognized
+ *    hub asset (a spoke-chain or otherwise-wrong address was passed).
+ *  - "No path was found between …" → both tokens are valid hub assets but the
+ *    solver couldn't route this pair *for this amount*; routing is liquidity-
+ *    dependent, so a smaller amount or a more liquid counterparty often works.
+ *
+ * Returns null for any other message so we never bolt a misleading hint onto an
+ * unrelated failure (timeouts, 5xx, contract drift, …).
+ */
+export function quoteErrorHint(message: string): string | null {
+  const m = message.toLowerCase();
+  if (m.includes("not compatible with the quote service")) {
+    return "Hint: one of the addresses isn't a recognized hub asset. tokenSrc/tokenDst must be hub-chain (Sonic, chainId 146) addresses — look one up via sodax_get_solver_oracle with chainId='146'. Spoke-chain and other non-hub addresses are rejected here.";
+  }
+  if (m.includes("no path was found")) {
+    return "Hint: both tokens are valid hub assets, but the solver couldn't route this pair for this amount. Routing is liquidity-dependent — retry with a smaller amount, or pick a more liquid counterparty (a canonical bridged *_ASSET hub token, or a major stablecoin like SONIC_USDC_ASSET). Wrapped/derivative entries (e.g. WBTC, waLoc*, soda*) are oracle-priced but frequently have no route.";
+  }
+  return null;
+}
+
 export function registerSolverRelayTools(server: McpServer): void {
   // ── Solver: oracle ──────────────────────────────────────────────────
   server.tool(
     "sodax_get_solver_oracle",
-    "Get the solver's oracle prices for every (chain, token) pair it can quote. Useful for sanity-checking quote amounts against USD prices the solver is using.",
+    "Get the solver's oracle USD prices per (chain, token). For quoting with sodax_get_solver_quote, filter chainId='146': every chainId-146 address listed here is accepted by the quote service (spoke-chain addresses are not). Caveat: being listed (priced) does NOT guarantee a swap route — canonical bridged *_ASSET hub tokens and major stablecoins route most reliably, while wrapped/derivative/money-market entries (e.g. WBTC, waLoc*, soda*, lsoda*, xSODA) are priced but frequently have no route, and routability is also liquidity/amount-dependent. Also useful for sanity-checking quote amounts against the USD prices the solver uses.",
     {
       chainId: z
         .string()
@@ -84,22 +109,22 @@ export function registerSolverRelayTools(server: McpServer): void {
   // ── Solver: quote ───────────────────────────────────────────────────
   server.tool(
     "sodax_get_solver_quote",
-    "Get a swap quote from the SODAX solver. IMPORTANT: tokenSrc/tokenDst must be hub-chain asset addresses — the SODAX hub is Sonic (chainId 146); spoke-chain token addresses are rejected with 'not compatible with the quote service'. Call sodax_get_solver_oracle with chainId='146' to look up valid token addresses. quote_type='exact_input' quotes the destination amount you'd receive; 'exact_output' quotes the source amount you'd need to supply. Returns 'No path found' if the solver can't route between the tokens.",
+    "Get a swap quote from the SODAX solver. tokenSrc/tokenDst MUST be hub-chain (Sonic, chainId 146) asset addresses — look them up with sodax_get_solver_oracle (chainId='146'). Working example: tokenSrc='0xeb0393893b5bf98a50073d6740738b08e575058b' (BTC_BTC_ASSET) → tokenDst='0xaeafa26e43f46cd83efe89b1e57c858eb5685a24' (ETH_ASSET), amount='99800', quoteType='exact_input' returns a quoted_amount. exact_input quotes the destination amount you'd receive; exact_output quotes the source amount you'd need. There are two distinct HTTP-400 failures, both naming the two addresses: (1) 'not compatible with the quote service' = an address isn't a recognized hub asset (a spoke-chain or wrong address was passed) → use a chainId-146 address from sodax_get_solver_oracle; (2) 'No path was found between X and Y' = both tokens are valid hub assets but the solver couldn't route this pair for this amount → routing is liquidity-dependent, so retry with a smaller amount or a more liquid counterparty (a canonical bridged *_ASSET token, or a major stablecoin like SONIC_USDC_ASSET). Wrapped/derivative/money-market entries (e.g. WBTC, waLoc*, soda*) are oracle-priced but frequently have no route — prefer canonical bridged *_ASSET hub tokens.",
     {
       tokenSrc: z
         .string()
         .describe(
-          "REQUIRED: Source token address (the token you're spending). Must be a hub-chain asset address (chainId 146) — look one up via sodax_get_solver_oracle.",
+          "REQUIRED: Source token address (the token you're spending). Hub-chain (Sonic, chainId 146) asset address from sodax_get_solver_oracle. Prefer canonical bridged *_ASSET tokens (e.g. BTC_BTC_ASSET 0xeb0393893b5bf98a50073d6740738b08e575058b); wrapped/derivative entries like WBTC are priced but often have no route.",
         ),
       tokenDst: z
         .string()
         .describe(
-          "REQUIRED: Destination token address (the token you want to receive). Must be a hub-chain asset address (chainId 146) — look one up via sodax_get_solver_oracle.",
+          "REQUIRED: Destination token address (the token you want to receive). Hub-chain (Sonic, chainId 146) asset address from sodax_get_solver_oracle (e.g. ETH_ASSET 0xaeafa26e43f46cd83efe89b1e57c858eb5685a24). Prefer canonical bridged *_ASSET tokens or a major stablecoin for a routable pair.",
         ),
       amount: z
         .string()
         .describe(
-          "REQUIRED: Amount in the smallest unit of the input token (for exact_input) or output token (for exact_output). String to preserve precision.",
+          "REQUIRED: Amount in the smallest unit of the input token (for exact_input) or output token (for exact_output). String to preserve precision. Note: a very large amount can exceed available liquidity and return 'No path was found' even for an otherwise-valid pair — reduce it if that happens.",
         ),
       quoteType: z
         .enum(["exact_input", "exact_output"])
@@ -133,8 +158,10 @@ export function registerSolverRelayTools(server: McpServer): void {
           ],
         };
       } catch (error) {
+        const message = error instanceof Error ? error.message : "Unknown error";
+        const hint = quoteErrorHint(message);
         return {
-          content: [{ type: "text", text: `Error: ${error instanceof Error ? error.message : "Unknown error"}` }],
+          content: [{ type: "text", text: hint ? `Error: ${message}\n\n${hint}` : `Error: ${message}` }],
           isError: true,
         };
       }


### PR DESCRIPTION
Addresses #64: the `sodax_get_solver_quote` / `sodax_get_solver_oracle` tools gave misleading token guidance ("use any chainId-146 address"), sending callers to tokens that fail with an opaque `HTTP 400` naming neither the offending token nor the reason.

**Verified against the live `api.sodax.com` endpoint**, there are two distinct failures (this corrects #64's original diagnosis):
- `not compatible with the quote service` — an address isn't a recognized chainId-146 hub asset (spoke-chain / wrong address). In sampling, only non-146 addresses hit this; no chainId-146 address did.
- `No path was found between X and Y` — a valid chainId-146 hub asset the solver can't route for this pair/amount. Routability is amount/liquidity-dependent (e.g. WBTC quotes at 0.001 but returns `No path` at 1.0), not a fixed per-token property.

This enriches both tool descriptions to distinguish the two failures, recommends canonical bridged `*_ASSET` hub tokens (and major stablecoins) as the reliable set with a concrete working example pair, and adds a `quoteErrorHint()` helper that appends an actionable next-step hint when the solver returns either error. New unit tests cover the hint mapping — substring matching, case-insensitivity, and returning null for unrelated errors so no misleading hint is appended; request construction is unchanged.

The guidance was validated end-to-end (n=59 live probes + every cited token) — see the ground-truth verification comment on this PR. Issue #64's proposed `quotable: boolean` oracle field is **dropped as ill-defined** (routability isn't per-token) — see the reconciliation comment on #64.

Closes #64