### PR TITLE
chore: promote development to master

### DIFF
--- a/src/tools/solverRelay.test.ts
+++ b/src/tools/solverRelay.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { quoteErrorHint } from "./solverRelay.js";
+
+describe("quoteErrorHint", () => {
+  it("hints to use a chainId-146 hub address when a token is not compatible", () => {
+    // Real upstream shape: `{ detail: { message: "One of the following tokens
+    // is not compatible with the quote service: 0x…, 0x…" } }`, surfaced by the
+    // http/service layers as part of the thrown Error message. Verified against
+    // the live API: this error fires only for spoke-chain / non-chainId-146
+    // addresses — every chainId-146 oracle address passes the compatibility check.
+    const message =
+      "Failed to fetch solver quote: HTTP 400 for https://api.sodax.com/v1/intent/quote - " +
+      "One of the following tokens is not compatible with the quote service: 0xabc, 0xdef";
+
+    const hint = quoteErrorHint(message);
+
+    expect(hint).not.toBeNull();
+    expect(hint).toContain("chainId 146");
+    expect(hint).toContain("sodax_get_solver_oracle");
+    // Steer to the reliable set — chainId 146 alone doesn't guarantee a route,
+    // so the hint must not regress to overly-broad "any chainId 146" guidance.
+    expect(hint).toContain("*_ASSET");
+  });
+
+  it("hints that 'no path' is liquidity/amount-dependent and recoverable", () => {
+    const message =
+      "Failed to fetch solver quote: HTTP 400 for https://api.sodax.com/v1/intent/quote - " +
+      "No path was found between 0xeb0393893b5bf98a50073d6740738b08e575058b and 0xaeafa26e43f46cd83efe89b1e57c858eb5685a24";
+
+    const hint = quoteErrorHint(message);
+
+    expect(hint).not.toBeNull();
+    expect(hint).toContain("smaller amount");
+    expect(hint).toContain("liquid");
+  });
+
+  it("is case-insensitive (matches regardless of upstream casing)", () => {
+    expect(quoteErrorHint("NOT COMPATIBLE WITH THE QUOTE SERVICE")).not.toBeNull();
+    expect(quoteErrorHint("NO PATH WAS FOUND between a and b")).not.toBeNull();
+  });
+
+  it("returns null for unrelated errors so no misleading hint is appended", () => {
+    expect(quoteErrorHint("Failed to fetch solver quote: HTTP 503 for … - upstream unavailable")).toBeNull();
+    expect(quoteErrorHint("The operation was aborted due to timeout")).toBeNull();
+    expect(quoteErrorHint("Unknown error")).toBeNull();
+  });
+});

--- a/src/tools/solverRelay.ts
+++ b/src/tools/solverRelay.ts
@@ -32,11 +32,42 @@ const RELAY_SUBMIT: ToolAnnotations = {
   openWorldHint: true,
 };
 
+/**
+ * Map an upstream solver-quote error to an actionable, caller-facing hint.
+ *
+ * The solver returns two distinct HTTP-400 failures (both already naming the
+ * two addresses), and the right next step differs (verified against the live
+ * api.sodax.com quote endpoint):
+ *  - "not compatible with the quote service" → one address isn't a recognized
+ *    hub asset. This fires for spoke-chain (non-chainId-146) or otherwise
+ *    unrecognized addresses; a chainId-146 hub asset passes this check (an
+ *    unroutable one fails later with "No path" instead). Passing the check
+ *    doesn't guarantee a route, so steer callers to the reliable set.
+ *  - "No path was found between …" → both tokens are valid chainId-146 hub
+ *    assets but the solver couldn't route this pair *for this amount*. Routing
+ *    is pair/amount/liquidity-dependent, so a smaller amount or a more liquid
+ *    counterparty often works. Many wrapped/derivative entries (e.g. WBTC,
+ *    waLocBTC, SONIC_SODA_ASSET) are oracle-priced but frequently unroutable.
+ *
+ * Returns null for any other message so we never bolt a misleading hint onto an
+ * unrelated failure (timeouts, 5xx, contract drift, …).
+ */
+export function quoteErrorHint(message: string): string | null {
+  const m = message.toLowerCase();
+  if (m.includes("not compatible with the quote service")) {
+    return "Hint: one of the addresses isn't a recognized hub asset — spoke-chain and other non-146 addresses are rejected here. Use a hub-chain (Sonic, chainId 146) asset address from sodax_get_solver_oracle; for a reliable next pick prefer a canonical bridged *_ASSET hub token (e.g. BTC_BTC_ASSET, ETH_ASSET) or a major stablecoin like SONIC_USDC_ASSET — chainId 146 alone doesn't guarantee a route.";
+  }
+  if (m.includes("no path was found")) {
+    return "Hint: both tokens are valid hub assets, but the solver couldn't route this pair for this amount. Routing is pair/amount/liquidity-dependent — retry with a smaller amount, or pick a more liquid counterparty (a canonical bridged *_ASSET hub token, or a major stablecoin like SONIC_USDC_ASSET). Many wrapped/derivative entries (e.g. WBTC, waLocBTC, SONIC_SODA_ASSET) are oracle-priced but frequently have no route.";
+  }
+  return null;
+}
+
 export function registerSolverRelayTools(server: McpServer): void {
   // ── Solver: oracle ──────────────────────────────────────────────────
   server.tool(
     "sodax_get_solver_oracle",
-    "Get the solver's oracle prices for every (chain, token) pair it can quote. Useful for sanity-checking quote amounts against USD prices the solver is using.",
+    "Get the solver's oracle USD prices per (chain, token). For quoting with sodax_get_solver_quote, filter chainId='146': chainId-146 addresses pass the quote service's compatibility check, while spoke-chain (non-146) addresses are rejected with 'not compatible with the quote service'. Caveat: passing that check (being listed/priced) does NOT guarantee a swap route — canonical bridged *_ASSET hub tokens and major stablecoins route most reliably, while many wrapped/derivative/money-market entries (e.g. WBTC, waLocBTC, SONIC_SODA_ASSET) are priced but frequently return 'No path was found', and routability is pair/amount/liquidity-dependent. Also useful for sanity-checking quote amounts against the USD prices the solver uses.",
     {
       chainId: z
         .string()
@@ -84,22 +115,22 @@ export function registerSolverRelayTools(server: McpServer): void {
   // ── Solver: quote ───────────────────────────────────────────────────
   server.tool(
     "sodax_get_solver_quote",
-    "Get a swap quote from the SODAX solver. IMPORTANT: tokenSrc/tokenDst must be hub-chain asset addresses — the SODAX hub is Sonic (chainId 146); spoke-chain token addresses are rejected with 'not compatible with the quote service'. Call sodax_get_solver_oracle with chainId='146' to look up valid token addresses. quote_type='exact_input' quotes the destination amount you'd receive; 'exact_output' quotes the source amount you'd need to supply. Returns 'No path found' if the solver can't route between the tokens.",
+    "Get a swap quote from the SODAX solver. tokenSrc/tokenDst MUST be hub-chain (Sonic, chainId 146) asset addresses — look them up with sodax_get_solver_oracle (chainId='146'). Working example: tokenSrc='0xeb0393893b5bf98a50073d6740738b08e575058b' (BTC_BTC_ASSET) → tokenDst='0xaeafa26e43f46cd83efe89b1e57c858eb5685a24' (ETH_ASSET), amount='99800', quoteType='exact_input' returns a quoted_amount. exact_input quotes the destination amount you'd receive; exact_output quotes the source amount you'd need. There are two distinct HTTP-400 failures, both naming the two addresses: (1) 'not compatible with the quote service' = an address isn't a recognized hub asset (a spoke-chain or otherwise non-chainId-146 address was passed) → use a chainId-146 address from sodax_get_solver_oracle, and for a reliable pick prefer a canonical bridged *_ASSET hub token or major stablecoin (chainId 146 alone doesn't guarantee a route). (2) 'No path was found between X and Y' = both tokens are valid hub assets but the solver couldn't route this pair for this amount → routing is pair/amount/liquidity-dependent, so retry with a smaller amount or a more liquid counterparty (a canonical bridged *_ASSET token, or a major stablecoin like SONIC_USDC_ASSET). Many wrapped/derivative entries (e.g. WBTC, waLocBTC, SONIC_SODA_ASSET) are oracle-priced but frequently have no route — prefer canonical bridged *_ASSET hub tokens.",
     {
       tokenSrc: z
         .string()
         .describe(
-          "REQUIRED: Source token address (the token you're spending). Must be a hub-chain asset address (chainId 146) — look one up via sodax_get_solver_oracle.",
+          "REQUIRED: Source token address (the token you're spending). Hub-chain (Sonic, chainId 146) asset address from sodax_get_solver_oracle. Prefer canonical bridged *_ASSET tokens (e.g. BTC_BTC_ASSET 0xeb0393893b5bf98a50073d6740738b08e575058b); wrapped/derivative entries like WBTC are priced but frequently have no route.",
         ),
       tokenDst: z
         .string()
         .describe(
-          "REQUIRED: Destination token address (the token you want to receive). Must be a hub-chain asset address (chainId 146) — look one up via sodax_get_solver_oracle.",
+          "REQUIRED: Destination token address (the token you want to receive). Hub-chain (Sonic, chainId 146) asset address from sodax_get_solver_oracle (e.g. ETH_ASSET 0xaeafa26e43f46cd83efe89b1e57c858eb5685a24). Prefer canonical bridged *_ASSET tokens or a major stablecoin for a routable pair.",
         ),
       amount: z
         .string()
         .describe(
-          "REQUIRED: Amount in the smallest unit of the input token (for exact_input) or output token (for exact_output). String to preserve precision.",
+          "REQUIRED: Amount in the smallest unit of the input token (for exact_input) or output token (for exact_output). String to preserve precision. Note: a very large amount can exceed available liquidity and return 'No path was found' even for an otherwise-valid pair — reduce it if that happens.",
         ),
       quoteType: z
         .enum(["exact_input", "exact_output"])
@@ -133,8 +164,10 @@ export function registerSolverRelayTools(server: McpServer): void {
           ],
         };
       } catch (error) {
+        const message = error instanceof Error ? error.message : "Unknown error";
+        const hint = quoteErrorHint(message);
         return {
-          content: [{ type: "text", text: `Error: ${error instanceof Error ? error.message : "Unknown error"}` }],
+          content: [{ type: "text", text: hint ? `Error: ${message}\n\n${hint}` : `Error: ${message}` }],
           isError: true,
         };
       }


### PR DESCRIPTION
Promote merged work from `development` to `master` (production — https://builders.sodax.com).

### Included
- #65 — feat: clarify solver quote token guidance and add error hints (`7914d32`)
  - Adds `quoteErrorHint()` mapping the two distinct solver-quote 400s to actionable next-step hints, and enriches the `sodax_get_solver_quote` / `sodax_get_solver_oracle` tool descriptions to match the API-verified error model. Closes #64.
  - Guidance validated end-to-end against the live `api.sodax.com` endpoint (n=59 probes + every cited token); see the ground-truth verification comment on #65.

### On merge (automated)
- Coolify auto-deploys `master` → **production**.
- `release-please` opens a release PR — this is a `feat:`, so a **minor** bump (1.4.0 → 1.5.0); merging it cuts the tag + GitHub Release.
- `sync-to-development` fast-forwards `development` back to `master`.