### PR TITLE
Promote to master: landing page refresh + review hardening (#66)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
   <a href="https://mcp.so/server/sodax-builders-mcp/gosodax"><img src="https://img.shields.io/badge/mcp.so-SODAX_Builders_MCP-8B5CF6?style=for-the-badge" alt="mcp.so" /></a>
 </p>
 
-SODAX MCP server for AI coding assistants. Access live cross-network (cross-chain) API data: swap tokens across 17+ networks, query money market rates, look up solver volume, and search intent history. Includes full cross-chain SDK documentation that auto-syncs from SODAX developer docs. Build cross-network DeFi integrations with real-time protocol data directly in your development workflow.
+SODAX MCP server for AI coding assistants. Access live cross-network (cross-chain) API data: swap tokens across 19+ networks, query money market rates, look up solver volume, and search intent history. Includes full cross-chain SDK documentation that auto-syncs from SODAX developer docs. Build cross-network DeFi integrations with real-time protocol data directly in your development workflow.
 
-**One-liner:** SODAX MCP server: live cross-network DeFi API data and auto-updating SDK docs for 17+ networks. Query swaps, lending, solver volume, and intent history from your AI coding assistant.
+**One-liner:** SODAX MCP server: live cross-network DeFi API data and auto-updating SDK docs for 19+ networks. Query swaps, lending, solver volume, and intent history from your AI coding assistant.
 
 ## Quick Start
 
@@ -58,7 +58,7 @@ For clients that don't support streamable HTTP (e.g. Gemini CLI), use the SSE en
 | `sodax_get_money_market_tokens` | Money market supported tokens by chain |
 | `sodax_get_money_market_reserve_assets` | Money market reserve assets |
 
-### Intents & Solver (8 tools)
+### Intents & Solver (9 tools)
 
 | Tool | Description |
 |------|-------------|
@@ -66,6 +66,7 @@ For clients that don't support streamable HTTP (e.g. Gemini CLI), use the SSE en
 | `sodax_get_intent` | Look up a specific intent by its intent hash |
 | `sodax_get_user_transactions` | Get intent/transaction history for a specific wallet address |
 | `sodax_get_volume` | Get solver volume data (filled intents) with filtering and pagination |
+| `sodax_get_volume_stats` | Get aggregated solver volume statistics |
 | `sodax_get_orderbook` | Get current cross-chain orderbook entries from solver |
 | `sodax_get_solver_intent` | Get solver-side intent details and fill history |
 | `sodax_get_solver_oracle` | Get the solver's oracle prices for every supported (chain, token) pair |
@@ -115,6 +116,7 @@ Tools prefixed with `docs_` are automatically proxied from the GitBook MCP at do
 | Tool | Description |
 |------|-------------|
 | `docs_searchDocumentation` | Search cross-chain SDK docs, integration guides, and code examples |
+| `docs_getPage` | Fetch a full documentation page |
 | `docs_list_tools` | List all available documentation tools |
 | `docs_health` | Check GitBook MCP connection status |
 | `docs_refresh` | Refresh the tools list from GitBook |

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -14,6 +14,12 @@ export const SODAX_RELAY_BASE_URL = "https://xcall-relay.nw.iconblockchain.xyz";
 // Cache duration in milliseconds (2 minutes for live data)
 export const CACHE_DURATION_MS = 2 * 60 * 1000;
 
+// Spoke chain keys excluded from the public "integrated networks" count.
+// Values are chain-key strings as returned by /config/spoke/chains (not numeric
+// chain IDs). ICON (0x1.icon) is being wound down, so it's filtered out — this
+// mirrors the frontend's stats.ts fetchIntegratedNetworksCount() source of truth.
+export const NETWORK_COUNT_EXCLUDED_CHAIN_KEYS: readonly string[] = ["0x1.icon"];
+
 // SODAX Brand Colors (for reference)
 export const BRAND_COLORS = {
   cherry: "#E53935",

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,12 +17,15 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import express, { Request, Response } from "express";
 import rateLimit from "express-rate-limit";
 import helmet from "helmet";
-import { STATIC_TOOL_COUNTS, hashClientIp, shutdownAnalytics, withAnalytics } from "./services/analytics.js";
+import { hashClientIp, shutdownAnalytics, withAnalytics } from "./services/analytics.js";
 import { checkApiDrift } from "./services/apiDriftCheck.js";
 import { notifyError, notifyServerStarted, notifyServerStopping } from "./services/discord.js";
-import { checkGitBookHealth, fetchGitBookTools } from "./services/gitbookProxy.js";
+import { fetchGitBookTools, getCachedGitBookHealth } from "./services/gitbookProxy.js";
+import { formatNetworkCount, renderLandingPage } from "./services/landingPage.js";
 import { logger } from "./services/logger.js";
-import { getGitBookToolNames, registerGitBookProxyTools } from "./tools/gitbookProxy.js";
+import { getIntegratedNetworksCount } from "./services/sodaxApi.js";
+import { getStaticToolCounts, getToolNamesByModule } from "./services/toolRegistry.js";
+import { getCachedGitBookToolNames, registerGitBookProxyTools } from "./tools/gitbookProxy.js";
 import { registerSodaxApiTools } from "./tools/sodaxApi.js";
 import { registerSolverRelayTools } from "./tools/solverRelay.js";
 
@@ -53,6 +56,27 @@ async function createServer(clientId?: string): Promise<McpServer> {
   await registerGitBookProxyTools(server);
 
   return server;
+}
+
+/**
+ * Seed the module-level tool registry that `/health`, `/api`, and the landing
+ * page read their counts from, without touching GitBook. Only the static SODAX
+ * + relay tools feed those counts — `getStaticToolCounts()` and
+ * `getToolNamesByModule()` skip the `sdkDocs` module, whose live total comes
+ * from `getGitBookToolNames()`.
+ *
+ * `registerAppTool()` records `{name, module, description}` in the registry as a
+ * side effect, so a no-op recording server (whose `tool()` does nothing) is
+ * enough — no real `McpServer` is built and no MCP registration runs here; that
+ * only happens on the per-request servers. Mirrors the fake server in
+ * `toolRegistry.test.ts`. This also skips `registerGitBookProxyTools()`, whose
+ * blocking GitBook fetch (up to 30s) would otherwise delay HTTP boot when
+ * GitBook is unavailable and `warmGitBookCache()` left the cache empty.
+ */
+function seedToolRegistry(): void {
+  const recordingServer = { tool: () => ({}) } as unknown as McpServer;
+  registerSodaxApiTools(recordingServer);
+  registerSolverRelayTools(recordingServer);
 }
 
 // GitBook proxy state
@@ -110,6 +134,12 @@ async function runHTTP(): Promise<void> {
   logger.info("Initializing GitBook SDK docs proxy...");
   await warmGitBookCache();
 
+  // Seed the tool registry that /health, /api, and the landing page derive
+  // their counts from (per-request server instances are only created lazily).
+  // Static SODAX + relay tools are all those counts need, so this skips the
+  // GitBook proxy registration and never blocks HTTP boot on a GitBook fetch.
+  seedToolRegistry();
+
   const app = express();
 
   // Trust the reverse proxy (Coolify/Traefik) so X-Forwarded-For is used for rate limiting
@@ -151,23 +181,76 @@ async function runHTTP(): Promise<void> {
   });
 
   app.use(express.json({ limit: "100kb" }));
+
+  // Landing page: the HTML template is read once at startup and served with
+  // live counts injected server-side (see services/landingPage.ts). These
+  // routes must be registered BEFORE express.static, which would otherwise
+  // serve the raw template with un-substituted {{PLACEHOLDER}} tokens.
+  let landingTemplate: string | null = null;
+  try {
+    landingTemplate = readFileSync(join(__dirname, "public", "index.html"), "utf-8");
+  } catch (error) {
+    logger.warn({ err: error }, "Landing page template missing — / will redirect to /api");
+  }
+
+  const serveLandingPage = async (_req: Request, res: Response): Promise<void> => {
+    if (!landingTemplate) {
+      res.redirect("/api");
+      return;
+    }
+    // Best-effort; renderLandingPage falls back to the evergreen floor on null.
+    let networks: number | null = null;
+    try {
+      networks = await getIntegratedNetworksCount();
+    } catch (error) {
+      logger.warn({ err: error }, "Failed to fetch integrated networks count for landing page");
+    }
+    // Non-blocking: derive the docs count from the warmed cache so a cold or
+    // expired GitBook cache can't stall the landing page on a 30s fetch — it
+    // renders with the cached (or meta-only) count instead.
+    const sdkDocsToolCount = getCachedGitBookToolNames().length;
+    res.type("html").send(renderLandingPage(landingTemplate, { networks, sdkDocsToolCount }));
+  };
+
+  app.get("/", serveLandingPage);
+  app.get("/index.html", serveLandingPage);
+
   app.use(express.static(join(__dirname, "public")));
 
   app.get("/health", async (_req: Request, res: Response) => {
-    const gitbookHealth = await checkGitBookHealth();
-    const gitbookToolNames = await getGitBookToolNames();
-    // Per-group breakdown derived from analytics' TOOL_GROUPS (single source
-    // of truth). `api` covers backend + solver tools; `relay` covers the
-    // intent-relay tools; `sdkDocs` is the dynamic GitBook proxy.
-    const apiToolCount = STATIC_TOOL_COUNTS.api ?? 0;
-    const relayToolCount = STATIC_TOOL_COUNTS.relay ?? 0;
+    // Non-blocking: read GitBook health/tool counts from the warmed cache so a
+    // cold or expired cache can't stall the health check on a 30s GitBook fetch
+    // (orchestrators treat a slow /health as unhealthy). warmGitBookCache() and
+    // per-request servers keep the cache fresh; docs_health does the live probe.
+    const gitbookHealth = getCachedGitBookHealth();
+    const gitbookToolNames = getCachedGitBookToolNames();
+    // Per-group breakdown derived from the tool registry. `api` covers backend
+    // + solver tools; `relay` the intent-relay tools; `sdkDocs` the dynamic
+    // GitBook proxy.
+    const staticToolCounts = getStaticToolCounts();
+    const apiToolCount = staticToolCounts.api;
+    const relayToolCount = staticToolCounts.relay;
     const sdkDocsToolCount = gitbookToolNames.length;
     const totalTools = apiToolCount + relayToolCount + sdkDocsToolCount;
+    // Live integrated-networks count (ICON filtered out), mirroring the
+    // frontend. Best-effort: a backend hiccup must not fail the health check,
+    // so this stays null and callers fall back to the evergreen floor.
+    let networks: number | null = null;
+    try {
+      const count = await getIntegratedNetworksCount();
+      // Normalize a non-positive count to null so clients keep the evergreen
+      // floor instead of surfacing a "0+" (which is worse than the fallback),
+      // mirroring formatNetworkCount's null|0 handling.
+      networks = count > 0 ? count : null;
+    } catch (error) {
+      logger.warn({ err: error }, "Failed to fetch integrated networks count for /health");
+    }
     res.json({
       status: "healthy",
       service: "builders-sodax-mcp-server",
       version: SERVER_VERSION,
       uptime_seconds: Math.floor(process.uptime()),
+      networks,
       tools: {
         total: totalTools,
         api: apiToolCount,
@@ -221,64 +304,28 @@ async function runHTTP(): Promise<void> {
     await session.transport.handlePostMessage(req, res, req.body);
   });
 
-  app.get("/", (_req: Request, res: Response) => {
-    try {
-      const html = readFileSync(join(__dirname, "public", "index.html"), "utf-8");
-      res.type("html").send(html);
-    } catch {
-      res.redirect("/api");
-    }
-  });
-
   app.get("/api", async (_req: Request, res: Response) => {
-    // Get dynamic list of GitBook tools
-    const gitbookTools = await getGitBookToolNames();
+    // Non-blocking: docs tool list from the warmed cache (see /health) so a cold
+    // or expired GitBook cache can't stall the response on a 30s fetch.
+    const gitbookTools = getCachedGitBookToolNames();
+
+    // Best-effort live network count for the description; evergreen fallback.
+    let networks: number | null = null;
+    try {
+      networks = await getIntegratedNetworksCount();
+    } catch (error) {
+      logger.warn({ err: error }, "Failed to fetch integrated networks count for /api");
+    }
 
     res.json({
       name: "SODAX Builders MCP Server",
       version: SERVER_VERSION,
-      description:
-        "Live cross-network DeFi API data, AMM analytics, money market insights, and auto-updating SDK docs for 17+ networks",
+      description: `Live cross-network DeFi API data, AMM analytics, money market insights, and auto-updating SDK docs for ${formatNetworkCount(networks)} networks`,
       endpoints: { mcp: "/mcp", sse: "/sse", messages: "/messages", health: "/health", api: "/api" },
+      // Tool lists derived from the tool registry; sdkDocs reflects the live
+      // GitBook proxy list.
       tools: {
-        config: [
-          "sodax_get_supported_chains",
-          "sodax_get_swap_tokens",
-          "sodax_get_all_config",
-          "sodax_get_relay_chain_id_map",
-          "sodax_get_all_chains_configs",
-          "sodax_get_hub_assets",
-          "sodax_get_money_market_tokens",
-          "sodax_get_money_market_reserve_assets",
-        ],
-        intents: [
-          "sodax_get_transaction",
-          "sodax_get_intent",
-          "sodax_get_user_transactions",
-          "sodax_get_volume",
-          "sodax_get_orderbook",
-          "sodax_get_solver_intent",
-          "sodax_get_solver_oracle",
-          "sodax_get_solver_quote",
-        ],
-        relay: ["sodax_relay_submit_tx", "sodax_relay_get_transaction_packets", "sodax_relay_get_packet"],
-        amm: ["sodax_get_amm_positions", "sodax_get_amm_pool_candles"],
-        moneyMarket: [
-          "sodax_get_money_market_assets",
-          "sodax_get_money_market_asset",
-          "sodax_get_user_position",
-          "sodax_get_asset_borrowers",
-          "sodax_get_asset_suppliers",
-          "sodax_get_all_borrowers",
-        ],
-        partnersAndToken: [
-          "sodax_get_partners",
-          "sodax_get_partner_summary",
-          "sodax_get_token_supply",
-          "sodax_get_total_supply",
-          "sodax_get_circulating_supply",
-          "sodax_refresh_cache",
-        ],
+        ...getToolNamesByModule(),
         sdkDocs: gitbookTools,
       },
       sdkDocsProxy: {

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -7,7 +7,7 @@
   <!-- Primary Meta Tags -->
   <title>SODAX MCP Server | Cross-Network (Cross-Chain) DeFi API Data & SDK Docs</title>
   <meta name="title" content="SODAX MCP Server | Cross-Network (Cross-Chain) DeFi API Data & SDK Docs">
-  <meta name="description" content="SODAX MCP server: live cross-network DeFi API data and auto-updating SDK docs for 17+ networks. Query swaps, lending, solver volume, and intent history from your AI coding assistant.">
+  <meta name="description" content="SODAX MCP server: live cross-network DeFi API data and auto-updating SDK docs for {{NETWORK_COUNT}} networks. Query swaps, lending, solver volume, and intent history from your AI coding assistant.">
   <meta name="keywords" content="MCP server, Model Context Protocol, SODAX, cross-chain swap, cross-network swap, multi chain swap, cross-chain SDK, cross-chain liquidity, cross-chain bridge aggregator, swap across chains, DeFi API, cross-chain developer tools, intent based swap, solver network, cross-chain execution, money market, blockchain SDK, AI coding assistant">
   <meta name="author" content="ICON Foundation">
   <meta name="robots" content="index, follow">
@@ -17,7 +17,7 @@
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://builders.sodax.com/">
   <meta property="og:title" content="SODAX MCP Server | Cross-Network DeFi API & SDK Docs">
-  <meta property="og:description" content="SODAX MCP server: live cross-network DeFi API data and auto-updating SDK docs for 17+ networks. Query swaps, lending, solver volume, and intent history from your AI coding assistant.">
+  <meta property="og:description" content="SODAX MCP server: live cross-network DeFi API data and auto-updating SDK docs for {{NETWORK_COUNT}} networks. Query swaps, lending, solver volume, and intent history from your AI coding assistant.">
   <meta property="og:image" content="https://builders.sodax.com/images/link-preview.png">
   <meta property="og:site_name" content="SODAX">
 
@@ -25,7 +25,7 @@
   <meta property="twitter:card" content="summary_large_image">
   <meta property="twitter:url" content="https://builders.sodax.com/">
   <meta property="twitter:title" content="SODAX MCP Server | Cross-Network DeFi API & SDK Docs">
-  <meta property="twitter:description" content="SODAX MCP server: live cross-network DeFi API data and auto-updating SDK docs for 17+ networks. Query swaps, lending, solver volume, and intent history from your AI coding assistant.">
+  <meta property="twitter:description" content="SODAX MCP server: live cross-network DeFi API data and auto-updating SDK docs for {{NETWORK_COUNT}} networks. Query swaps, lending, solver volume, and intent history from your AI coding assistant.">
   <meta property="twitter:image" content="https://builders.sodax.com/images/link-preview.png">
   
   <!-- Favicon -->
@@ -56,7 +56,7 @@
     "name": "SODAX Builders MCP Server",
     "applicationCategory": "DeveloperApplication",
     "operatingSystem": "Cross-platform",
-    "description": "SODAX MCP server for AI coding assistants. Access live cross-network (cross-chain) API data: swap tokens across 17+ networks, query money market rates, look up solver volume, and search intent history. Includes full cross-chain SDK documentation that auto-syncs from SODAX developer docs.",
+    "description": "SODAX MCP server for AI coding assistants. Access live cross-network (cross-chain) API data: swap tokens across {{NETWORK_COUNT}} networks, query money market rates, look up solver volume, and search intent history. Includes full cross-chain SDK documentation that auto-syncs from SODAX developer docs.",
     "url": "https://builders.sodax.com/",
     "author": {
       "@type": "Organization",
@@ -69,7 +69,7 @@
       "priceCurrency": "USD"
     },
     "featureList": [
-      "Cross-network (cross-chain) swap token queries across 17+ networks",
+      "Cross-network (cross-chain) swap token queries across {{NETWORK_COUNT}} networks",
       "Full protocol configuration and relay chain ID mapping",
       "Solver volume and intent history lookup",
       "Money market lending and borrowing rates with borrower/supplier analytics",
@@ -94,7 +94,7 @@
         "name": "What is the SODAX MCP server?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "The SODAX MCP server gives AI coding assistants live access to cross-network DeFi API data across 17+ blockchain networks. Query swap tokens, money market rates, solver volume, intent history, and auto-updating SDK documentation directly from tools like Claude, Cursor, VS Code, and ChatGPT."
+          "text": "The SODAX MCP server gives AI coding assistants live access to cross-network DeFi API data across {{NETWORK_COUNT}} blockchain networks. Query swap tokens, money market rates, solver volume, intent history, and auto-updating SDK documentation directly from tools like Claude, Cursor, VS Code, and ChatGPT."
         }
       },
       {
@@ -102,7 +102,7 @@
         "name": "What is a cross-chain swap and how does SODAX handle it?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "A cross-chain swap lets you exchange tokens between different blockchain networks without traditional bridging. SODAX uses an intent-based execution model with a decentralized solver network to fill swaps across 17+ networks with unified cross-chain liquidity."
+          "text": "A cross-chain swap lets you exchange tokens between different blockchain networks without traditional bridging. SODAX uses an intent-based execution model with a decentralized solver network to fill swaps across {{NETWORK_COUNT}} networks with unified cross-chain liquidity."
         }
       },
       {
@@ -110,7 +110,7 @@
         "name": "Which blockchain networks does the SODAX cross-chain SDK support?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "SODAX supports 17+ blockchain networks for cross-network swaps and DeFi operations. Use the sodax_get_supported_chains tool to get the live list of supported networks, or search the auto-syncing SDK documentation for integration guides."
+          "text": "SODAX supports {{NETWORK_COUNT}} blockchain networks for cross-network swaps and DeFi operations. Use the sodax_get_supported_chains tool to get the live list of supported networks, or search the auto-syncing SDK documentation for integration guides."
         }
       },
       {
@@ -226,7 +226,7 @@
 
     /* Hero Section */
     .hero {
-      background: var(--cherry-soda);
+      background: var(--cherry-dark);
       padding: 5rem 2rem;
       text-align: center;
       position: relative;
@@ -916,87 +916,136 @@
     /* Footer */
     footer {
       background: var(--almost-white);
-      padding: 5rem 2rem;
+      padding: 7.5rem 2rem;
     }
 
     .footer-container {
       max-width: 944px;
       margin: 0 auto;
-      display: flex;
-      justify-content: space-between;
-      align-items: flex-start;
-      flex-wrap: wrap;
-      gap: 3rem;
     }
 
-    .footer-brand {
-      max-width: 260px;
+    .footer-top {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: flex-start;
+      justify-content: space-between;
+      row-gap: 2.5rem;
     }
 
     .footer-logo {
+      flex-shrink: 0;
       font-family: var(--font-primary);
       font-size: 1.5rem;
       font-weight: 900;
-      color: var(--espresso);
-      margin-bottom: 1rem;
+      color: var(--cherry-grey);
       display: flex;
       align-items: center;
       gap: 0.5rem;
     }
 
-    .footer-logo img {
-      width: 24px;
-      height: 24px;
+    .footer-logo-mark {
+      display: inline-block;
+      width: 30px;
+      height: 32px;
+    }
+
+    .footer-nav {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 2.5rem;
+    }
+
+    .footer-column {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+
+    .footer-column h4 {
+      font-family: var(--font-primary);
+      font-size: 0.5625rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      color: var(--clay-light);
+      line-height: 1.2;
+    }
+
+    .footer-link {
+      font-size: 0.75rem;
+      color: #000;
+      text-decoration: none;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      line-height: 1.4;
+      transition: color 0.2s;
+    }
+
+    .footer-link:hover {
+      color: var(--cherry-bright);
+    }
+
+    .footer-arrow {
+      width: 16px;
+      height: 16px;
+      color: var(--cherry-bright);
+      transition: stroke-width 0.2s;
+    }
+
+    .footer-link:hover .footer-arrow {
+      stroke-width: 3.5;
+    }
+
+    /* Cross-network product pills */
+    .footer-pill {
+      display: inline-flex;
+      align-items: center;
+      width: fit-content;
+      height: 1.5rem;
+      padding: 0.125rem 0.75rem 0;
+      border-radius: 9999px;
+      background: var(--cream-white);
+      color: var(--espresso);
+      font-size: 0.75rem;
+      line-height: 1.4;
+      text-decoration: none;
+      border: 2px solid transparent;
+      transition: background 0.2s, border-color 0.2s;
+    }
+
+    .footer-pill:hover {
+      background: var(--cherry-grey);
+    }
+
+    .footer-pill--outline {
+      background: transparent;
+      border-color: var(--cream-white);
+      color: var(--clay);
+    }
+
+    .footer-pill--outline:hover {
+      background: transparent;
+      border-color: var(--cherry-grey);
+    }
+
+    .footer-divider {
+      margin-top: 1.5rem;
+      border-top: 1px solid rgba(185, 172, 171, 0.3);
+    }
+
+    .footer-bottom {
+      margin-top: 1.5rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
     }
 
     .footer-copyright {
       font-size: 0.75rem;
-      font-weight: 500;
-      color: var(--cherry-bright);
+      color: var(--clay-light);
       line-height: 1.4;
     }
 
-    .footer-links {
-      display: flex;
-      gap: 2.5rem;
-      flex-wrap: wrap;
-    }
-
-    .footer-column h4 {
-      font-family: var(--font-display);
-      font-style: italic;
-      font-size: 1rem;
-      color: var(--cherry-bright);
-      margin-bottom: 0.5rem;
-      line-height: 1.1;
-    }
-
-    .footer-column ul {
-      list-style: none;
-    }
-
-    .footer-column li {
-      margin-bottom: 0.25rem;
-    }
-
-    .footer-column a {
-      font-size: 0.75rem;
-      color: var(--espresso);
-      text-decoration: none;
-      display: inline-flex;
-      align-items: center;
-      gap: 0.25rem;
-      transition: color 0.2s;
-    }
-
-    .footer-column a:hover {
-      color: var(--cherry-bright);
-    }
-
-    .footer-column a .external::after {
-      content: '↗';
-      font-size: 0.625rem;
-    }
 
     /* Responsive */
     @media (max-width: 640px) {
@@ -1020,8 +1069,8 @@
         grid-template-columns: 1fr;
       }
 
-      .footer-container {
-        flex-direction: column;
+      footer {
+        padding: 5rem 1.5rem;
       }
     }
   </style>
@@ -1055,7 +1104,7 @@
   <header class="hero" role="banner">
     <div class="hero-content">
       <p class="hero-eyebrow">SODAX Builders MCP Server</p>
-      <h1>Cross-network DeFi data. <span class="accent">17+ networks.</span></h1>
+      <h1>Cross-network DeFi data. <span class="accent"><span class="js-network-count">{{NETWORK_COUNT}}</span> networks.</span></h1>
       <p class="hero-subtitle">Access live cross-network API data from your AI coding assistant: swap tokens across chains, query money market rates, look up solver volume, and search intent history. Includes auto-syncing SDK docs.</p>
       
       <div class="hero-url-box">
@@ -1114,7 +1163,7 @@
           </div>
           <p>"What networks does SODAX support for cross-chain swaps?"</p>
           <div class="badge-row">
-            <span class="badge">17+ Networks</span>
+            <span class="badge"><span class="js-network-count">{{NETWORK_COUNT}}</span> Networks</span>
             <span class="badge">Cross-chain</span>
           </div>
         </div>
@@ -1188,7 +1237,7 @@
       <div class="section-title">
         <h2 id="tools-heading">Available Tools</h2>
       </div>
-      <p class="section-subtitle">32 tools: cross-network API data, AMM analytics, money market insights, and SDK documentation — all in one connection.</p>
+      <p class="section-subtitle">{{TOTAL_TOOLS}} tools: cross-network API data, AMM analytics, money market insights, and SDK documentation — all in one connection.</p>
       
       <div class="tools-grid">
         <details class="tool-module">
@@ -1201,14 +1250,14 @@
               </div>
             </div>
             <div class="tool-summary-right">
-              <span class="badge">8 tools</span>
+              <span class="badge">{{CONFIG_TOOLS}} tools</span>
               <span class="tool-source-tag">SODAX API</span>
               <svg class="tool-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m6 9 6 6 6-6"/></svg>
             </div>
           </summary>
           <div class="tool-detail">
             <div class="tool-list">
-              <div class="tool-item"><code>sodax_get_supported_chains</code><span>List 17+ supported networks</span></div>
+              <div class="tool-item"><code>sodax_get_supported_chains</code><span>List {{NETWORK_COUNT}} supported networks</span></div>
               <div class="tool-item"><code>sodax_get_swap_tokens</code><span>Cross-network swap tokens by chain</span></div>
               <div class="tool-item"><code>sodax_get_all_config</code><span>Full config (chains + tokens) in one call</span></div>
               <div class="tool-item"><code>sodax_get_all_chains_configs</code><span>Detailed spoke chain configs</span></div>
@@ -1230,7 +1279,7 @@
               </div>
             </div>
             <div class="tool-summary-right">
-              <span class="badge">6 tools</span>
+              <span class="badge">{{INTENTS_TOOLS}} tools</span>
               <span class="tool-source-tag">SODAX API</span>
               <svg class="tool-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m6 9 6 6 6-6"/></svg>
             </div>
@@ -1241,8 +1290,35 @@
               <div class="tool-item"><code>sodax_get_intent</code><span>Intent lookup by intent hash</span></div>
               <div class="tool-item"><code>sodax_get_user_transactions</code><span>Wallet intent history</span></div>
               <div class="tool-item"><code>sodax_get_volume</code><span>Solver volume (filled intents)</span></div>
+              <div class="tool-item"><code>sodax_get_volume_stats</code><span>Aggregated solver volume stats</span></div>
               <div class="tool-item"><code>sodax_get_orderbook</code><span>Cross-chain orderbook</span></div>
               <div class="tool-item"><code>sodax_get_solver_intent</code><span>Solver-side intent details & fill history</span></div>
+              <div class="tool-item"><code>sodax_get_solver_oracle</code><span>Solver oracle prices per (chain, token)</span></div>
+              <div class="tool-item"><code>sodax_get_solver_quote</code><span>Swap quote (exact_input or exact_output)</span></div>
+            </div>
+          </div>
+        </details>
+
+        <details class="tool-module">
+          <summary>
+            <div class="tool-summary-left">
+              <div class="tool-icon"><i data-lucide="radio"></i></div>
+              <div class="tool-summary-text">
+                <h3>Intent Relay</h3>
+                <p>Submit spoke txs and track cross-chain relay packets end to end</p>
+              </div>
+            </div>
+            <div class="tool-summary-right">
+              <span class="badge">{{RELAY_TOOLS}} tools</span>
+              <span class="tool-source-tag">Intent Relay</span>
+              <svg class="tool-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m6 9 6 6 6-6"/></svg>
+            </div>
+          </summary>
+          <div class="tool-detail">
+            <div class="tool-list">
+              <div class="tool-item"><code>sodax_relay_submit_tx</code><span>Submit a confirmed spoke tx to the relay</span></div>
+              <div class="tool-item"><code>sodax_relay_get_transaction_packets</code><span>List cross-chain packets from a source tx</span></div>
+              <div class="tool-item"><code>sodax_relay_get_packet</code><span>Fetch a single packet by connection serial</span></div>
             </div>
           </div>
         </details>
@@ -1257,7 +1333,7 @@
               </div>
             </div>
             <div class="tool-summary-right">
-              <span class="badge">2 tools</span>
+              <span class="badge">{{AMM_TOOLS}} tools</span>
               <span class="tool-source-tag">SODAX API</span>
               <svg class="tool-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m6 9 6 6 6-6"/></svg>
             </div>
@@ -1280,7 +1356,7 @@
               </div>
             </div>
             <div class="tool-summary-right">
-              <span class="badge">6 tools</span>
+              <span class="badge">{{MONEY_MARKET_TOOLS}} tools</span>
               <span class="tool-source-tag">SODAX API</span>
               <svg class="tool-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m6 9 6 6 6-6"/></svg>
             </div>
@@ -1307,7 +1383,7 @@
               </div>
             </div>
             <div class="tool-summary-right">
-              <span class="badge">6 tools</span>
+              <span class="badge">{{PARTNERS_TOOLS}} tools</span>
               <span class="tool-source-tag">SODAX API</span>
               <svg class="tool-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m6 9 6 6 6-6"/></svg>
             </div>
@@ -1334,7 +1410,7 @@
               </div>
             </div>
             <div class="tool-summary-right">
-              <span class="badge">4 tools</span>
+              <span class="badge">{{SDK_DOCS_TOOLS}} tools</span>
               <span class="tool-source-tag">GitBook</span>
               <svg class="tool-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m6 9 6 6 6-6"/></svg>
             </div>
@@ -1342,6 +1418,7 @@
           <div class="tool-detail">
             <div class="tool-list">
               <div class="tool-item"><code>docs_searchDocumentation</code><span>Search SDK docs, examples, guides</span></div>
+              <div class="tool-item"><code>docs_getPage</code><span>Fetch a full documentation page</span></div>
               <div class="tool-item"><code>docs_list_tools</code><span>List available doc tools</span></div>
               <div class="tool-item"><code>docs_health</code><span>Check docs connection</span></div>
               <div class="tool-item"><code>docs_refresh</code><span>Refresh tools list</span></div>
@@ -1475,7 +1552,7 @@
             <svg class="tool-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m6 9 6 6 6-6"/></svg>
           </summary>
           <div class="tool-detail">
-            <p style="padding-top: 1rem; font-size: 0.875rem; color: var(--clay-dark); line-height: 1.6;">The SODAX Builders MCP server gives AI coding assistants live access to cross-network DeFi API data across 17+ blockchain networks. Query swap tokens, money market rates, solver volume, intent history, and auto-updating SDK documentation directly from tools like Claude, Cursor, VS Code, and ChatGPT.</p>
+            <p style="padding-top: 1rem; font-size: 0.875rem; color: var(--clay-dark); line-height: 1.6;">The SODAX Builders MCP server gives AI coding assistants live access to cross-network DeFi API data across {{NETWORK_COUNT}} blockchain networks. Query swap tokens, money market rates, solver volume, intent history, and auto-updating SDK documentation directly from tools like Claude, Cursor, VS Code, and ChatGPT.</p>
           </div>
         </details>
 
@@ -1489,7 +1566,7 @@
             <svg class="tool-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m6 9 6 6 6-6"/></svg>
           </summary>
           <div class="tool-detail">
-            <p style="padding-top: 1rem; font-size: 0.875rem; color: var(--clay-dark); line-height: 1.6;">A cross-chain swap lets you exchange tokens between different blockchain networks without traditional bridging. SODAX uses an intent-based execution model with a decentralized solver network to fill swaps across 17+ networks with unified cross-chain liquidity. The MCP server lets you query available swap tokens, look up intent transactions, and check solver volume programmatically.</p>
+            <p style="padding-top: 1rem; font-size: 0.875rem; color: var(--clay-dark); line-height: 1.6;">A cross-chain swap lets you exchange tokens between different blockchain networks without traditional bridging. SODAX uses an intent-based execution model with a decentralized solver network to fill swaps across {{NETWORK_COUNT}} networks with unified cross-chain liquidity. The MCP server lets you query available swap tokens, look up intent transactions, and check solver volume programmatically.</p>
           </div>
         </details>
 
@@ -1503,7 +1580,7 @@
             <svg class="tool-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m6 9 6 6 6-6"/></svg>
           </summary>
           <div class="tool-detail">
-            <p style="padding-top: 1rem; font-size: 0.875rem; color: var(--clay-dark); line-height: 1.6;">SODAX supports 17+ blockchain networks for cross-network swaps and DeFi operations. Use the <code style="background: var(--espresso); color: var(--yellow-accent); padding: 0.15rem 0.4rem; border-radius: 4px; font-size: 0.8125rem;">sodax_get_supported_chains</code> tool to get the live list, or search the auto-syncing SDK documentation for integration guides per network.</p>
+            <p style="padding-top: 1rem; font-size: 0.875rem; color: var(--clay-dark); line-height: 1.6;">SODAX supports {{NETWORK_COUNT}} blockchain networks for cross-network swaps and DeFi operations. Use the <code style="background: var(--espresso); color: var(--yellow-accent); padding: 0.15rem 0.4rem; border-radius: 4px; font-size: 0.8125rem;">sodax_get_supported_chains</code> tool to get the live list, or search the auto-syncing SDK documentation for integration guides per network.</p>
           </div>
         </details>
 
@@ -1542,37 +1619,39 @@
   <!-- Footer -->
   <footer role="contentinfo">
     <div class="footer-container">
-      <div class="footer-brand">
-        <div class="footer-logo"><img src="/images/symbol.png" alt="SODAX" width="24" height="24"> SODAX</div>
-        <p class="footer-copyright">© 2026 ICON Foundation.<br>All rights reserved.</p>
+      <div class="footer-top">
+        <div class="footer-logo"><svg class="footer-logo-mark" width="30" height="32" viewBox="0 0 29.3333 32" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M11.8644 11.4094L2.4581 5.80599L0 10.1942L6.98101 14.3461L11.8644 11.4094Z" fill="currentColor"/><path d="M22.3523 14.3461L29.3333 10.1942L26.8752 5.80599L17.4361 11.4094L22.3523 14.3461Z" fill="currentColor"/><path d="M14.6502 9.75527L17.1083 8.3038V0H12.1921V8.3038L14.6502 9.75527Z" fill="currentColor"/><path d="M29.3333 21.8059L17.1084 14.5485L14.6503 13.097L0 21.8059L2.4581 26.194L9.76685 21.8396C9.99628 21.7046 10.2585 21.6033 10.5534 21.6033C11.4711 21.6033 12.1922 22.3459 12.1922 23.2911V32H17.1084V23.2911C17.1084 22.3459 17.8294 21.6033 18.7471 21.6033C19.0421 21.6033 19.3043 21.7046 19.5337 21.8396L26.8752 26.1603L29.3333 21.8059Z" fill="currentColor"/></svg> SODAX</div>
+
+        <nav class="footer-nav" aria-label="Footer">
+          <div class="footer-column">
+            <h4>Cross-network products</h4>
+            <a class="footer-pill" href="https://docs.sodax.com/developers/packages/foundation/sdk/functional-modules/swaps" target="_blank" rel="noopener noreferrer">Intent swaps for apps</a>
+            <a class="footer-pill" href="https://docs.sodax.com/developers/packages/foundation/sdk/functional-modules/money_market" target="_blank" rel="noopener noreferrer">Lend / Borrow for apps</a>
+            <a class="footer-pill" href="https://docs.sodax.com/developers/packages/foundation/sdk/functional-modules/bridge" target="_blank" rel="noopener noreferrer">Bridge service</a>
+          </div>
+
+          <div class="footer-column">
+            <h4>Socials</h4>
+            <a class="footer-link" href="https://x.com/gosodax" target="_blank" rel="noopener noreferrer">X (Twitter)<i data-lucide="arrow-up-right" class="footer-arrow" aria-hidden="true"></i></a>
+            <a class="footer-link" href="https://www.sodax.com/discord" target="_blank" rel="noopener noreferrer">Discord<i data-lucide="arrow-up-right" class="footer-arrow" aria-hidden="true"></i></a>
+            <a class="footer-link" href="https://www.linkedin.com/company/gosodax" target="_blank" rel="noopener noreferrer">LinkedIn<i data-lucide="arrow-up-right" class="footer-arrow" aria-hidden="true"></i></a>
+            <a class="footer-link" href="https://github.com/icon-project" target="_blank" rel="noopener noreferrer">GitHub<i data-lucide="arrow-up-right" class="footer-arrow" aria-hidden="true"></i></a>
+          </div>
+
+          <div class="footer-column">
+            <h4>Resources</h4>
+            <a class="footer-link" href="/api">API Info</a>
+            <a class="footer-link" href="/health">Health Check</a>
+            <a class="footer-link" href="https://docs.sodax.com" target="_blank" rel="noopener noreferrer">Documentation<i data-lucide="arrow-up-right" class="footer-arrow" aria-hidden="true"></i></a>
+            <a class="footer-link" href="https://sodaxscan.com/" target="_blank" rel="noopener noreferrer">Transaction scanner<i data-lucide="arrow-up-right" class="footer-arrow" aria-hidden="true"></i></a>
+          </div>
+        </nav>
       </div>
-      
-      <div class="footer-links">
-        <div class="footer-column">
-          <h4>resources</h4>
-          <ul>
-            <li><a href="/api">API Info</a></li>
-            <li><a href="/health">Health Check</a></li>
-            <li><a href="https://docs.sodax.com" class="external">Documentation ↗</a></li>
-          </ul>
-        </div>
-        
-        <div class="footer-column">
-          <h4>socials</h4>
-          <ul>
-            <li><a href="https://discord.gg/sodax" class="external">Discord ↗</a></li>
-            <li><a href="https://twitter.com/sodax" class="external">X (Twitter) ↗</a></li>
-            <li><a href="https://github.com/icon-project" class="external">GitHub ↗</a></li>
-          </ul>
-        </div>
-        
-        <div class="footer-column">
-          <h4>using soda</h4>
-          <ul>
-            <li><a href="https://hanawallet.io" class="external">Hana Wallet ↗</a></li>
-            <li><a href="https://balanced.network" class="external">Balanced DeFi ↗</a></li>
-          </ul>
-        </div>
+
+      <div class="footer-divider"></div>
+
+      <div class="footer-bottom">
+        <p class="footer-copyright">© 2026 SODAX. All rights reserved.</p>
       </div>
     </div>
   </footer>
@@ -1611,6 +1690,7 @@
       const text = document.getElementById('status-text');
       const version = document.getElementById('status-version');
       const tools = document.getElementById('status-tools');
+      const networkCounts = document.querySelectorAll('.js-network-count');
 
       async function checkHealth() {
         try {
@@ -1620,6 +1700,11 @@
           text.textContent = 'Online';
           version.textContent = 'v' + (data.version || '1.0.2');
           tools.textContent = (data.tools?.total || 0) + ' available';
+          // Live integrated-networks count (ICON filtered out, server-side).
+          // Falls back to the static markup when the backend is unavailable.
+          if (typeof data.networks === 'number') {
+            networkCounts.forEach((el) => { el.textContent = data.networks + '+'; });
+          }
         } catch {
           dot.className = 'status-dot offline';
           text.textContent = 'Offline';

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -11,6 +11,7 @@
 import { createHash } from "node:crypto";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { PostHog } from "posthog-node";
+import { getToolModule } from "./toolRegistry.js";
 
 // ── Configuration ────────────────────────────────────────────────────
 const POSTHOG_API_KEY = process.env.POSTHOG_API_KEY || "";
@@ -18,88 +19,19 @@ const POSTHOG_HOST = process.env.POSTHOG_HOST || "https://eu.i.posthog.com";
 const DISTINCT_ID = process.env.POSTHOG_DISTINCT_ID || "sodax-builders-mcp";
 const SERVER_NAME = process.env.POSTHOG_SERVER_NAME || "builders-mcp";
 
-// ── Tool → Group mapping ─────────────────────────────────────────────
-// Map every tool name to a logical group for PostHog filtering.
-// Update this when you add or remove tools.
-const TOOL_GROUPS: Record<string, string> = {
-  // SODAX API tools — config
-  sodax_get_supported_chains: "api",
-  sodax_get_swap_tokens: "api",
-  sodax_get_all_config: "api",
-  sodax_get_relay_chain_id_map: "api",
-  sodax_get_all_chains_configs: "api",
-  sodax_get_hub_assets: "api",
-  sodax_get_money_market_tokens: "api",
-  sodax_get_money_market_reserve_assets: "api",
-
-  // SODAX API tools — intents & solver
-  sodax_get_transaction: "api",
-  sodax_get_user_transactions: "api",
-  sodax_get_intent: "api",
-  sodax_get_volume: "api",
-  sodax_get_volume_stats: "api",
-  sodax_get_orderbook: "api",
-  sodax_get_solver_intent: "api",
-  sodax_get_solver_oracle: "api",
-  sodax_get_solver_quote: "api",
-
-  // SODAX intent-relay tools
-  sodax_relay_submit_tx: "relay",
-  sodax_relay_get_transaction_packets: "relay",
-  sodax_relay_get_packet: "relay",
-
-  // SODAX API tools — AMM
-  sodax_get_amm_positions: "api",
-  sodax_get_amm_pool_candles: "api",
-
-  // SODAX API tools — money market
-  sodax_get_money_market_assets: "api",
-  sodax_get_money_market_asset: "api",
-  sodax_get_asset_borrowers: "api",
-  sodax_get_asset_suppliers: "api",
-  sodax_get_all_borrowers: "api",
-  sodax_get_user_position: "api",
-
-  // SODAX API tools — partners & token
-  sodax_get_partners: "api",
-  sodax_get_partner_summary: "api",
-  sodax_get_token_supply: "api",
-  sodax_get_total_supply: "api",
-  sodax_get_circulating_supply: "api",
-  sodax_refresh_cache: "api",
-
-  // GitBook SDK docs meta-tools
-  docs_health: "sdk-docs",
-  docs_refresh: "sdk-docs",
-  docs_list_tools: "sdk-docs",
-};
-
 /**
- * Resolve tool group — static map first, then prefix-based fallback
- * for dynamically registered GitBook proxy tools (docs_*).
+ * Resolve tool group for PostHog filtering — derived from the tool registry,
+ * with a prefix-based fallback for dynamically registered GitBook proxy tools
+ * (docs_*) which are not in the registry.
  */
 function resolveToolGroup(toolName: string): string {
-  if (TOOL_GROUPS[toolName]) return TOOL_GROUPS[toolName];
+  const module = getToolModule(toolName);
+  if (module === "relay") return "relay";
+  if (module === "sdkDocs") return "sdk-docs";
+  if (module) return "api";
   if (toolName.startsWith("docs_")) return "sdk-docs";
   return "unknown";
 }
-
-/**
- * Per-group tool counts derived from `TOOL_GROUPS`. Keeps `/health` in sync
- * with the analytics map automatically — no hard-coded number, no drift.
- *
- * Example shape: `{ api: 30, relay: 3, "sdk-docs": 3 }`. Consumers should
- * use `STATIC_TOOL_COUNTS.api` / `STATIC_TOOL_COUNTS.relay` and **exclude**
- * `"sdk-docs"` from any "static" total (those meta-tools are wrapped around
- * the dynamic GitBook proxy and counted separately at runtime).
- */
-export const STATIC_TOOL_COUNTS: Record<string, number> = Object.values(TOOL_GROUPS).reduce(
-  (acc, group) => {
-    acc[group] = (acc[group] ?? 0) + 1;
-    return acc;
-  },
-  {} as Record<string, number>,
-);
 
 // ── PostHog client (lazy singleton) ──────────────────────────────────
 let client: PostHog | null = null;

--- a/src/services/apiDriftCheck.ts
+++ b/src/services/apiDriftCheck.ts
@@ -65,7 +65,7 @@ const IGNORED_PATHS: Record<EndpointKey, string> = {
  * and the spec as of first-write (responseFields). When upstream drifts,
  * the check flags the diff so a human updates either the tool or this map.
  */
-const TOOL_CONTRACT: Record<EndpointKey, ToolContract> = {
+export const TOOL_CONTRACT: Record<EndpointKey, ToolContract> = {
   "GET /config/all": {
     tool: "sodax_get_all_config",
     params: [],

--- a/src/services/gitbookProxy.ts
+++ b/src/services/gitbookProxy.ts
@@ -200,6 +200,30 @@ export async function checkGitBookHealth(): Promise<{ healthy: boolean; toolCoun
 }
 
 /**
+ * Names of the currently cached GitBook tools WITHOUT triggering a network
+ * fetch. Returns a fresh array of the cached tool names (even if expired), or an
+ * empty array if nothing has been cached yet. Names are immutable strings and
+ * the array is a copy, so callers cannot mutate the cache through it. Lets
+ * display-count callers avoid blocking on a 30s GitBook request when the cache
+ * is cold or expired.
+ */
+export function getCachedGitBookToolNames(): string[] {
+  return (cachedTools ?? []).map(t => t.name);
+}
+
+/**
+ * GitBook proxy health derived from the current cache WITHOUT a network fetch:
+ * `healthy` is true once tools have been cached (a successful fetch happened),
+ * `toolCount` is the cached proxy-tool count. Lets `/health` report proxy
+ * status without blocking up to 30s on a live fetch when GitBook is
+ * unreachable — unlike `checkGitBookHealth()`, which awaits `fetchGitBookTools()`.
+ */
+export function getCachedGitBookHealth(): { healthy: boolean; toolCount: number } {
+  const toolCount = cachedTools?.length ?? 0;
+  return { healthy: toolCount > 0, toolCount };
+}
+
+/**
  * Clear the tools cache to force a refresh
  */
 export function clearGitBookCache(): void {

--- a/src/services/landingPage.ts
+++ b/src/services/landingPage.ts
@@ -1,0 +1,50 @@
+/**
+ * Landing-page server-side rendering.
+ *
+ * `src/public/index.html` ships with `{{PLACEHOLDER}}` tokens for every
+ * number that used to be hardcoded (network count, tool counts). This module
+ * substitutes live values derived from the tool registry and runtime state,
+ * so the page — including the SEO surfaces crawlers read without running JS
+ * (meta description, og:/twitter: tags, JSON-LD) — can never drift from what
+ * the server actually exposes. The `.js-network-count` client-side refresh
+ * in the page remains as a graceful fallback.
+ */
+
+import { getStaticToolCounts, getToolCountsByModule } from "./toolRegistry.js";
+
+export interface LandingPageData {
+  /** Live integrated-networks count, or null when the backend fetch failed. */
+  networks: number | null;
+  /** Runtime count of docs_* tools (GitBook proxies + meta-tools). */
+  sdkDocsToolCount: number;
+}
+
+/** Evergreen floor used when the live network count is unavailable. */
+const NETWORK_COUNT_FALLBACK = "19+";
+
+/** "19+"-style string from the live count, or the evergreen floor when it's
+ * unavailable (null) or zero — a "0+" surface would be worse than the floor. */
+export function formatNetworkCount(networks: number | null): string {
+  return networks !== null && networks > 0 ? `${networks}+` : NETWORK_COUNT_FALLBACK;
+}
+
+/** Substitute every {{PLACEHOLDER}} in the landing-page template. */
+export function renderLandingPage(template: string, data: LandingPageData): string {
+  const moduleCounts = getToolCountsByModule();
+  const staticCounts = getStaticToolCounts();
+  const totalTools = staticCounts.api + staticCounts.relay + data.sdkDocsToolCount;
+
+  const values: Record<string, string> = {
+    NETWORK_COUNT: formatNetworkCount(data.networks),
+    TOTAL_TOOLS: String(totalTools),
+    CONFIG_TOOLS: String(moduleCounts.config),
+    INTENTS_TOOLS: String(moduleCounts.intents),
+    RELAY_TOOLS: String(moduleCounts.relay),
+    AMM_TOOLS: String(moduleCounts.amm),
+    MONEY_MARKET_TOOLS: String(moduleCounts.moneyMarket),
+    PARTNERS_TOOLS: String(moduleCounts.partnersAndToken),
+    SDK_DOCS_TOOLS: String(data.sdkDocsToolCount),
+  };
+
+  return template.replace(/\{\{([A-Z_]+)\}\}/g, (match, key: string) => values[key] ?? match);
+}

--- a/src/services/sodaxApi.ts
+++ b/src/services/sodaxApi.ts
@@ -5,9 +5,8 @@
  * Provides access to chains, tokens, transactions, volume, and more.
  */
 
-import { CACHE_DURATION_MS, SODAX_API_BASE_URL } from "../constants.js";
+import { CACHE_DURATION_MS, NETWORK_COUNT_EXCLUDED_CHAIN_KEYS, SODAX_API_BASE_URL } from "../constants.js";
 import type {
-  Chain,
   MoneyMarketAsset,
   OrderbookEntry,
   Partner,
@@ -48,23 +47,38 @@ function apiUrl(path: string): string {
 }
 
 /**
- * Get all supported blockchain networks
+ * Get all supported blockchain networks.
+ *
+ * The `/config/spoke/chains` endpoint returns an array of chain-key strings
+ * (e.g. "0x2105.base", "sonic", "0x1.icon"), NOT chain objects — the return
+ * type reflects that so callers can filter on the keys directly.
  */
-export async function getSupportedChains(): Promise<Chain[]> {
+export async function getSupportedChains(): Promise<string[]> {
   const cacheKey = "chains";
-  const cached = getCached<Chain[]>(cacheKey);
+  const cached = getCached<string[]>(cacheKey);
   if (cached) return cached;
 
   try {
     const data = await fetchJson<unknown>(apiUrl("/config/spoke/chains"));
-    // API returns array directly
-    const chains = Array.isArray(data) ? (data as Chain[]) : (data as { data?: Chain[] })?.data || [];
+    // API returns the array of chain keys directly.
+    const chains = Array.isArray(data) ? (data as string[]) : (data as { data?: string[] })?.data || [];
     setCache(cacheKey, chains);
     return chains;
   } catch (error) {
     logger.error({ err: error }, "Failed to fetch supported chains");
     throw new Error("Failed to fetch supported chains from SODAX API");
   }
+}
+
+/**
+ * Count of publicly integrated networks, mirroring the frontend's
+ * stats.ts fetchIntegratedNetworksCount(): the length of /config/spoke/chains
+ * with wound-down chains (ICON) filtered out. Reuses getSupportedChains so it
+ * shares the 2-minute cache.
+ */
+export async function getIntegratedNetworksCount(): Promise<number> {
+  const chains = await getSupportedChains();
+  return chains.filter(key => !NETWORK_COUNT_EXCLUDED_CHAIN_KEYS.includes(key)).length;
 }
 
 /**

--- a/src/services/toolRegistry.test.ts
+++ b/src/services/toolRegistry.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Guardrails for the tool registry and the landing-page placeholder system.
+ *
+ * These tests fail when someone reintroduces a hand-maintained count that can
+ * drift from what the server actually registers — the same spirit as the
+ * apiDriftCheck, pointed inward.
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { beforeAll, describe, expect, it } from "vitest";
+import { registerSodaxApiTools } from "../tools/sodaxApi.js";
+import { registerSolverRelayTools } from "../tools/solverRelay.js";
+import { TOOL_CONTRACT } from "./apiDriftCheck.js";
+import { renderLandingPage } from "./landingPage.js";
+import {
+  getRegisteredTools,
+  getStaticToolCounts,
+  getToolCountsByModule,
+  getToolNamesByModule,
+} from "./toolRegistry.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const INDEX_HTML_PATH = join(__dirname, "..", "public", "index.html");
+
+/** Minimal stand-in — registerAppTool only needs server.tool() to exist. */
+const fakeServer = { tool: () => ({}) } as unknown as McpServer;
+
+beforeAll(() => {
+  // Populate the registry the same way createServer() does (minus the
+  // network-dependent GitBook proxy — its tools are dynamic by design).
+  registerSodaxApiTools(fakeServer);
+  registerSolverRelayTools(fakeServer);
+});
+
+describe("tool registry", () => {
+  it("registers every tool exactly once", () => {
+    const names = getRegisteredTools().map(t => t.name);
+    expect(names.length).toBeGreaterThan(0);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it("has at least one tool in every static module", () => {
+    const counts = getToolCountsByModule();
+    for (const [module, count] of Object.entries(counts)) {
+      expect(count, `module "${module}" has no tools`).toBeGreaterThan(0);
+    }
+  });
+
+  it("static api/relay counts add up to the grouped /api lists", () => {
+    const { api, relay } = getStaticToolCounts();
+    const groups = getToolNamesByModule();
+    expect(relay).toBe(groups.relay.length);
+    expect(api).toBe(
+      groups.config.length +
+        groups.intents.length +
+        groups.amm.length +
+        groups.moneyMarket.length +
+        groups.partnersAndToken.length,
+    );
+  });
+
+  it("covers every tool the API drift-check contract claims exists", () => {
+    const registered = new Set(getRegisteredTools().map(t => t.name));
+    for (const contract of Object.values(TOOL_CONTRACT)) {
+      expect(registered.has(contract.tool), `contract tool "${contract.tool}" is not registered`).toBe(true);
+    }
+  });
+});
+
+describe("landing page template", () => {
+  const template = readFileSync(INDEX_HTML_PATH, "utf-8");
+
+  it("contains no hardcoded tool/network counts (placeholders only)", () => {
+    // e.g. "39 tools", "19+ networks", "8 tools" — these drift as tools are
+    // added; every displayed number must come from a {{PLACEHOLDER}}.
+    const literalCount = /\d+\+?\s+(tools|networks)\b/i.exec(template);
+    expect(literalCount, `hardcoded count "${literalCount?.[0]}" found in index.html`).toBeNull();
+  });
+
+  it("contains the expected placeholders", () => {
+    for (const key of [
+      "NETWORK_COUNT",
+      "TOTAL_TOOLS",
+      "CONFIG_TOOLS",
+      "INTENTS_TOOLS",
+      "RELAY_TOOLS",
+      "AMM_TOOLS",
+      "MONEY_MARKET_TOOLS",
+      "PARTNERS_TOOLS",
+      "SDK_DOCS_TOOLS",
+    ]) {
+      expect(template, `missing {{${key}}} in index.html`).toContain(`{{${key}}}`);
+    }
+  });
+
+  it("renders with every placeholder substituted", () => {
+    const html = renderLandingPage(template, { networks: 24, sdkDocsToolCount: 5 });
+    expect(html).not.toMatch(/\{\{[A-Z_]+\}\}/);
+    expect(html).toContain("24+");
+  });
+
+  it("falls back to the evergreen network floor when the live count is unavailable", () => {
+    const html = renderLandingPage(template, { networks: null, sdkDocsToolCount: 3 });
+    expect(html).toContain("19+");
+    expect(html).not.toMatch(/\{\{[A-Z_]+\}\}/);
+  });
+
+  it("derives the total tool count from the registry plus the live docs count", () => {
+    const { api, relay } = getStaticToolCounts();
+    const html = renderLandingPage("{{TOTAL_TOOLS}}", { networks: null, sdkDocsToolCount: 5 });
+    expect(html).toBe(String(api + relay + 5));
+  });
+});

--- a/src/services/toolRegistry.ts
+++ b/src/services/toolRegistry.ts
@@ -1,0 +1,122 @@
+/**
+ * Tool Registry — single source of truth for the tools this server exposes.
+ *
+ * Every static `server.tool()` registration in `src/tools/*.ts` is routed
+ * through `registerAppTool()`, which records `{ name, module, description }`
+ * exactly once. Everything that displays tool counts or lists — `/health`,
+ * `/api`, the landing-page placeholder injection, and PostHog analytics
+ * grouping — derives from this registry, so adding or removing a tool
+ * updates them all with no manual count edits.
+ *
+ * Dynamic GitBook proxy tools (`docs_getPage`, …) are intentionally NOT in
+ * the registry: they change at runtime and are counted via
+ * `getGitBookToolNames()` where needed. Only the three docs_* meta-tools
+ * are registered here (module "sdkDocs") so analytics can group them.
+ */
+
+import type { McpServer, ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { ZodRawShapeCompat } from "@modelcontextprotocol/sdk/server/zod-compat.js";
+import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
+
+/** Landing-page / `/api` module a tool belongs to. */
+export type ToolModule = "config" | "intents" | "relay" | "amm" | "moneyMarket" | "partnersAndToken" | "sdkDocs";
+
+export interface RegisteredToolInfo {
+  name: string;
+  module: ToolModule;
+  description: string;
+}
+
+const registry: RegisteredToolInfo[] = [];
+
+/**
+ * Register a tool with the MCP server AND record it in the registry.
+ * Signature mirrors the `server.tool(name, description, schema, annotations, cb)`
+ * overload used everywhere in `src/tools/*.ts`, plus a leading `module`.
+ *
+ * Safe to call on every per-request McpServer instance — the registry
+ * dedupes by tool name, the MCP registration happens each time.
+ */
+export function registerAppTool<Args extends ZodRawShapeCompat>(
+  server: McpServer,
+  module: ToolModule,
+  name: string,
+  description: string,
+  paramsSchema: Args,
+  annotations: ToolAnnotations,
+  cb: ToolCallback<Args>,
+): void {
+  if (!registry.some(t => t.name === name)) {
+    registry.push({ name, module, description });
+  }
+  server.tool(name, description, paramsSchema, annotations, cb);
+}
+
+/** Snapshot of every statically registered tool — entries are cloned, so
+ * callers can't mutate the singleton registry (safe to iterate/sort). */
+export function getRegisteredTools(): readonly RegisteredToolInfo[] {
+  return registry.map(t => ({ ...t }));
+}
+
+/** Registry lookup for analytics grouping; undefined for dynamic docs_* proxies. */
+export function getToolModule(toolName: string): ToolModule | undefined {
+  return registry.find(t => t.name === toolName)?.module;
+}
+
+/**
+ * Tool names grouped by module, in registration order — feeds the `/api`
+ * route. `sdkDocs` is excluded (the caller appends the live GitBook list).
+ */
+export function getToolNamesByModule(): Record<Exclude<ToolModule, "sdkDocs">, string[]> {
+  const groups: Record<Exclude<ToolModule, "sdkDocs">, string[]> = {
+    config: [],
+    intents: [],
+    relay: [],
+    amm: [],
+    moneyMarket: [],
+    partnersAndToken: [],
+  };
+  for (const tool of registry) {
+    if (tool.module === "sdkDocs") continue;
+    groups[tool.module].push(tool.name);
+  }
+  return groups;
+}
+
+/** Per-module counts for the landing-page badges (sdkDocs counted at runtime).
+ * Counts in a single pass rather than materializing name arrays just to read
+ * their length. */
+export function getToolCountsByModule(): Record<Exclude<ToolModule, "sdkDocs">, number> {
+  const counts: Record<Exclude<ToolModule, "sdkDocs">, number> = {
+    config: 0,
+    intents: 0,
+    relay: 0,
+    amm: 0,
+    moneyMarket: 0,
+    partnersAndToken: 0,
+  };
+  for (const tool of registry) {
+    if (tool.module === "sdkDocs") continue;
+    counts[tool.module]++;
+  }
+  return counts;
+}
+
+/**
+ * Static per-group counts for `/health`: `relay` is the intent-relay tools,
+ * `api` is every other static module (config, intents, amm, moneyMarket,
+ * partnersAndToken). docs_* meta-tools (module "sdkDocs") are excluded — the
+ * sdkDocs total is counted at runtime from the live GitBook tool list. Deriving
+ * `api` as "not relay, not sdkDocs" keeps it consistent with analytics'
+ * resolveToolGroup and means a newly added module is counted automatically
+ * rather than silently dropped by an allowlist.
+ */
+export function getStaticToolCounts(): { api: number; relay: number } {
+  let api = 0;
+  let relay = 0;
+  for (const tool of registry) {
+    if (tool.module === "relay") relay++;
+    else if (tool.module !== "sdkDocs") api++;
+  }
+  return { api, relay };
+}

--- a/src/tools/gitbookProxy.ts
+++ b/src/tools/gitbookProxy.ts
@@ -14,8 +14,10 @@ import {
   checkGitBookHealth,
   clearGitBookCache,
   fetchGitBookTools,
+  getCachedGitBookToolNames as getCachedRawGitBookToolNames,
 } from "../services/gitbookProxy.js";
 import { logger } from "../services/logger.js";
+import { registerAppTool } from "../services/toolRegistry.js";
 
 const DOCS_READ_ONLY: ToolAnnotations = {
   readOnlyHint: true,
@@ -151,7 +153,9 @@ export async function registerGitBookProxyTools(server: McpServer): Promise<numb
  */
 function registerGitBookMetaTools(server: McpServer): void {
   // Tool to check GitBook MCP health
-  server.tool(
+  registerAppTool(
+    server,
+    "sdkDocs",
     "docs_health",
     "Check SDK documentation availability. Call this first if docs tools seem unavailable.",
     {},
@@ -187,7 +191,9 @@ function registerGitBookMetaTools(server: McpServer): void {
   );
 
   // Tool to refresh GitBook tools
-  server.tool(
+  registerAppTool(
+    server,
+    "sdkDocs",
     "docs_refresh",
     "Reconnect to SDK documentation and refresh available tools. Use if docs seem stale or unavailable.",
     {},
@@ -220,7 +226,9 @@ function registerGitBookMetaTools(server: McpServer): void {
   );
 
   // Tool to list available docs tools with full details
-  server.tool(
+  registerAppTool(
+    server,
+    "sdkDocs",
     "docs_list_tools",
     "List all SDK documentation tools with parameters. Essential for discovering what's available.",
     {},
@@ -265,6 +273,9 @@ function registerGitBookMetaTools(server: McpServer): void {
   );
 }
 
+/** The three docs_* meta-tools that are always registered, even if GitBook is down. */
+const GITBOOK_META_TOOL_NAMES = ["docs_health", "docs_refresh", "docs_list_tools"];
+
 /**
  * Get list of registered GitBook tool names for API response
  */
@@ -272,8 +283,19 @@ export async function getGitBookToolNames(): Promise<string[]> {
   try {
     const tools = await fetchGitBookTools();
     const proxyTools = tools.map(t => `docs_${t.name}`);
-    return [...proxyTools, "docs_health", "docs_refresh", "docs_list_tools"];
+    return [...proxyTools, ...GITBOOK_META_TOOL_NAMES];
   } catch {
-    return ["docs_health", "docs_refresh", "docs_list_tools"];
+    return [...GITBOOK_META_TOOL_NAMES];
   }
+}
+
+/**
+ * Non-blocking variant of getGitBookToolNames: derives the docs_* names from the
+ * current tools cache (plus the always-available meta-tools) WITHOUT triggering
+ * a GitBook fetch. Used by display-count callers (e.g. the landing page) so a
+ * cold or expired cache never makes the response wait on a 30s GitBook request.
+ */
+export function getCachedGitBookToolNames(): string[] {
+  const proxyTools = getCachedRawGitBookToolNames().map(name => `docs_${name}`);
+  return [...proxyTools, ...GITBOOK_META_TOOL_NAMES];
 }

--- a/src/tools/sodaxApi.ts
+++ b/src/tools/sodaxApi.ts
@@ -41,6 +41,7 @@ import {
   getVolumeStats,
 } from "../services/sodaxApi.js";
 import { clearSolverCache, getSolverCacheStats } from "../services/solver.js";
+import { registerAppTool } from "../services/toolRegistry.js";
 import { ResponseFormat } from "../types.js";
 import { formatResponse } from "./formatters.js";
 
@@ -56,7 +57,9 @@ const READ_ONLY: ToolAnnotations = {
 
 export function registerSodaxApiTools(server: McpServer): void {
   // Tool 1: Get Supported Chains
-  server.tool(
+  registerAppTool(
+    server,
+    "config",
     "sodax_get_supported_chains",
     "List all blockchain networks supported by SODAX for cross-chain swaps and DeFi operations",
     {
@@ -88,7 +91,9 @@ export function registerSodaxApiTools(server: McpServer): void {
   );
 
   // Tool 2: Get Swap Tokens
-  server.tool(
+  registerAppTool(
+    server,
+    "config",
     "sodax_get_swap_tokens",
     "Get available tokens for swapping on SODAX, optionally filtered by chain",
     {
@@ -129,7 +134,9 @@ export function registerSodaxApiTools(server: McpServer): void {
   );
 
   // Tool 3: Get Transaction
-  server.tool(
+  registerAppTool(
+    server,
+    "intents",
     "sodax_get_transaction",
     "Look up a specific transaction by its hash to see status, amounts, and details",
     {
@@ -167,7 +174,9 @@ export function registerSodaxApiTools(server: McpServer): void {
   );
 
   // Tool 4: Get User Transactions
-  server.tool(
+  registerAppTool(
+    server,
+    "intents",
     "sodax_get_user_transactions",
     "Get intent/transaction history for a specific wallet address",
     {
@@ -212,7 +221,9 @@ export function registerSodaxApiTools(server: McpServer): void {
   );
 
   // Tool 5: Get Volume (Filled Intents)
-  server.tool(
+  registerAppTool(
+    server,
+    "intents",
     "sodax_get_volume",
     "Get solver volume data showing filled intents with filtering and pagination. Requires inputToken and outputToken. Optional filters: chain, solver, block range OR time range (don't mix both).",
     {
@@ -306,7 +317,9 @@ export function registerSodaxApiTools(server: McpServer): void {
   );
 
   // Tool 5b: Get Volume Stats (aggregate filled-intent count)
-  server.tool(
+  registerAppTool(
+    server,
+    "intents",
     "sodax_get_volume_stats",
     "Get aggregate solver volume stats: the approximate total number of filled-intent records (fill documents, not distinct intents). Cached ~60s upstream.",
     {
@@ -338,7 +351,9 @@ export function registerSodaxApiTools(server: McpServer): void {
   );
 
   // Tool 6: Get Orderbook
-  server.tool(
+  registerAppTool(
+    server,
+    "intents",
     "sodax_get_orderbook",
     "Get current orderbook entries showing pending/open intents",
     {
@@ -380,7 +395,9 @@ export function registerSodaxApiTools(server: McpServer): void {
   );
 
   // Tool 7: Get Money Market Assets
-  server.tool(
+  registerAppTool(
+    server,
+    "moneyMarket",
     "sodax_get_money_market_assets",
     "List all assets available for lending and borrowing in the SODAX money market",
     {
@@ -414,7 +431,9 @@ export function registerSodaxApiTools(server: McpServer): void {
   );
 
   // Tool 8: Get User Position
-  server.tool(
+  registerAppTool(
+    server,
+    "moneyMarket",
     "sodax_get_user_position",
     "Get a user's lending and borrowing position in the money market",
     {
@@ -452,7 +471,9 @@ export function registerSodaxApiTools(server: McpServer): void {
   );
 
   // Tool 9: Get Partners
-  server.tool(
+  registerAppTool(
+    server,
+    "partnersAndToken",
     "sodax_get_partners",
     "List all SODAX integration partners including wallets, DEXs, and other protocols",
     {
@@ -485,7 +506,9 @@ export function registerSodaxApiTools(server: McpServer): void {
   );
 
   // Tool 10: Get Token Supply
-  server.tool(
+  registerAppTool(
+    server,
+    "partnersAndToken",
     "sodax_get_token_supply",
     "Get SODA token supply information including total, circulating, and burned amounts",
     {
@@ -517,7 +540,9 @@ export function registerSodaxApiTools(server: McpServer): void {
   );
 
   // Tool 11: Get All Config
-  server.tool(
+  registerAppTool(
+    server,
+    "config",
     "sodax_get_all_config",
     "Get full SODAX configuration including all supported chains, swap tokens, and protocol settings in one call",
     {
@@ -549,7 +574,9 @@ export function registerSodaxApiTools(server: McpServer): void {
   );
 
   // Tool 12: Get Relay Chain ID Map
-  server.tool(
+  registerAppTool(
+    server,
+    "config",
     "sodax_get_relay_chain_id_map",
     "Get mapping between chain IDs and intent relay chain IDs used by the SODAX relay network",
     {
@@ -581,7 +608,9 @@ export function registerSodaxApiTools(server: McpServer): void {
   );
 
   // Tool 13: Get All Spoke Chain Configs
-  server.tool(
+  registerAppTool(
+    server,
+    "config",
     "sodax_get_all_chains_configs",
     "Get detailed configuration for all spoke chains including contract addresses, RPCs, and token configs",
     {
@@ -613,7 +642,9 @@ export function registerSodaxApiTools(server: McpServer): void {
   );
 
   // Tool 14: Get Hub Assets
-  server.tool(
+  registerAppTool(
+    server,
+    "config",
     "sodax_get_hub_assets",
     "Get assets representing spoke tokens on the hub (Sonic) chain, optionally filtered by source chain",
     {
@@ -652,7 +683,9 @@ export function registerSodaxApiTools(server: McpServer): void {
   );
 
   // Tool 15: Get Money Market Tokens
-  server.tool(
+  registerAppTool(
+    server,
+    "config",
     "sodax_get_money_market_tokens",
     "Get tokens supported for money market lending/borrowing, optionally filtered by chain",
     {
@@ -686,7 +719,9 @@ export function registerSodaxApiTools(server: McpServer): void {
   );
 
   // Tool 16: Get Money Market Reserve Assets
-  server.tool(
+  registerAppTool(
+    server,
+    "config",
     "sodax_get_money_market_reserve_assets",
     "Get money market reserve assets used as collateral backing",
     {
@@ -718,7 +753,9 @@ export function registerSodaxApiTools(server: McpServer): void {
   );
 
   // Tool 17: Get AMM NFT Positions
-  server.tool(
+  registerAppTool(
+    server,
+    "amm",
     "sodax_get_amm_positions",
     "Get AMM liquidity provider NFT positions, optionally filtered by owner address",
     {
@@ -756,7 +793,9 @@ export function registerSodaxApiTools(server: McpServer): void {
   );
 
   // Tool 18: Get AMM Pool Candles
-  server.tool(
+  registerAppTool(
+    server,
+    "amm",
     "sodax_get_amm_pool_candles",
     "Get OHLCV candlestick chart data for an AMM pool",
     {
@@ -793,7 +832,9 @@ export function registerSodaxApiTools(server: McpServer): void {
   );
 
   // Tool 19: Get Intent by Hash
-  server.tool(
+  registerAppTool(
+    server,
+    "intents",
     "sodax_get_intent",
     "Look up a specific intent by its intent hash (different from transaction hash)",
     {
@@ -831,7 +872,9 @@ export function registerSodaxApiTools(server: McpServer): void {
   );
 
   // Tool 20: Get Solver Intent Details
-  server.tool(
+  registerAppTool(
+    server,
+    "intents",
     "sodax_get_solver_intent",
     "Get solver-side details for an intent including fill history. Use includeAll to see all solver documents.",
     {
@@ -874,7 +917,9 @@ export function registerSodaxApiTools(server: McpServer): void {
   );
 
   // Tool 21: Get Single Money Market Asset
-  server.tool(
+  registerAppTool(
+    server,
+    "moneyMarket",
     "sodax_get_money_market_asset",
     "Get detailed information for a specific money market asset by its reserve address",
     {
@@ -912,7 +957,9 @@ export function registerSodaxApiTools(server: McpServer): void {
   );
 
   // Tool 22: Get Money Market Asset Borrowers
-  server.tool(
+  registerAppTool(
+    server,
+    "moneyMarket",
     "sodax_get_asset_borrowers",
     "Get borrowers for a specific money market asset by its reserve address",
     {
@@ -953,7 +1000,9 @@ export function registerSodaxApiTools(server: McpServer): void {
   );
 
   // Tool 23: Get Money Market Asset Suppliers
-  server.tool(
+  registerAppTool(
+    server,
+    "moneyMarket",
     "sodax_get_asset_suppliers",
     "Get suppliers (lenders) for a specific money market asset by its reserve address",
     {
@@ -994,7 +1043,9 @@ export function registerSodaxApiTools(server: McpServer): void {
   );
 
   // Tool 24: Get All Money Market Borrowers
-  server.tool(
+  registerAppTool(
+    server,
+    "moneyMarket",
     "sodax_get_all_borrowers",
     "Get all borrowers across all money market assets with pagination",
     {
@@ -1034,7 +1085,9 @@ export function registerSodaxApiTools(server: McpServer): void {
   );
 
   // Tool 25: Get Partner Summary
-  server.tool(
+  registerAppTool(
+    server,
+    "partnersAndToken",
     "sodax_get_partner_summary",
     "Get volume and activity summary for a specific integration partner by their receiver address",
     {
@@ -1073,7 +1126,9 @@ export function registerSodaxApiTools(server: McpServer): void {
   );
 
   // Tool 26: Get Total Supply
-  server.tool(
+  registerAppTool(
+    server,
+    "partnersAndToken",
     "sodax_get_total_supply",
     "Get SODA token total supply as a plain number",
     {
@@ -1105,7 +1160,9 @@ export function registerSodaxApiTools(server: McpServer): void {
   );
 
   // Tool 27: Get Circulating Supply
-  server.tool(
+  registerAppTool(
+    server,
+    "partnersAndToken",
     "sodax_get_circulating_supply",
     "Get SODA token circulating supply as a plain number",
     {
@@ -1137,7 +1194,9 @@ export function registerSodaxApiTools(server: McpServer): void {
   );
 
   // Bonus Tool: Refresh Cache
-  server.tool(
+  registerAppTool(
+    server,
+    "partnersAndToken",
     "sodax_refresh_cache",
     "Clear both the backend API cache and the solver oracle cache to force fresh fetches on next requests. Reports the number of entries cleared per cache.",
     {},

--- a/src/tools/solverRelay.ts
+++ b/src/tools/solverRelay.ts
@@ -13,6 +13,7 @@ import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import { getRelayPacket, getRelayTransactionPackets, submitRelayTx } from "../services/relay.js";
 import { getSolverOracle, getSolverQuote } from "../services/solver.js";
+import { registerAppTool } from "../services/toolRegistry.js";
 import { ResponseFormat } from "../types.js";
 import { formatResponse } from "./formatters.js";
 
@@ -65,7 +66,9 @@ export function quoteErrorHint(message: string): string | null {
 
 export function registerSolverRelayTools(server: McpServer): void {
   // ── Solver: oracle ──────────────────────────────────────────────────
-  server.tool(
+  registerAppTool(
+    server,
+    "intents",
     "sodax_get_solver_oracle",
     "Get the solver's oracle USD prices per (chain, token). For quoting with sodax_get_solver_quote, filter chainId='146': chainId-146 addresses pass the quote service's compatibility check, while spoke-chain (non-146) addresses are rejected with 'not compatible with the quote service'. Caveat: passing that check (being listed/priced) does NOT guarantee a swap route — canonical bridged *_ASSET hub tokens and major stablecoins route most reliably, while many wrapped/derivative/money-market entries (e.g. WBTC, waLocBTC, SONIC_SODA_ASSET) are priced but frequently return 'No path was found', and routability is pair/amount/liquidity-dependent. Also useful for sanity-checking quote amounts against the USD prices the solver uses.",
     {
@@ -113,7 +116,9 @@ export function registerSolverRelayTools(server: McpServer): void {
   );
 
   // ── Solver: quote ───────────────────────────────────────────────────
-  server.tool(
+  registerAppTool(
+    server,
+    "intents",
     "sodax_get_solver_quote",
     "Get a swap quote from the SODAX solver. tokenSrc/tokenDst MUST be hub-chain (Sonic, chainId 146) asset addresses — look them up with sodax_get_solver_oracle (chainId='146'). Working example: tokenSrc='0xeb0393893b5bf98a50073d6740738b08e575058b' (BTC_BTC_ASSET) → tokenDst='0xaeafa26e43f46cd83efe89b1e57c858eb5685a24' (ETH_ASSET), amount='99800', quoteType='exact_input' returns a quoted_amount. exact_input quotes the destination amount you'd receive; exact_output quotes the source amount you'd need. There are two distinct HTTP-400 failures, both naming the two addresses: (1) 'not compatible with the quote service' = an address isn't a recognized hub asset (a spoke-chain or otherwise non-chainId-146 address was passed) → use a chainId-146 address from sodax_get_solver_oracle, and for a reliable pick prefer a canonical bridged *_ASSET hub token or major stablecoin (chainId 146 alone doesn't guarantee a route). (2) 'No path was found between X and Y' = both tokens are valid hub assets but the solver couldn't route this pair for this amount → routing is pair/amount/liquidity-dependent, so retry with a smaller amount or a more liquid counterparty (a canonical bridged *_ASSET token, or a major stablecoin like SONIC_USDC_ASSET). Many wrapped/derivative entries (e.g. WBTC, waLocBTC, SONIC_SODA_ASSET) are oracle-priced but frequently have no route — prefer canonical bridged *_ASSET hub tokens.",
     {
@@ -175,7 +180,9 @@ export function registerSolverRelayTools(server: McpServer): void {
   );
 
   // ── Relay: submit ───────────────────────────────────────────────────
-  server.tool(
+  registerAppTool(
+    server,
+    "relay",
     "sodax_relay_submit_tx",
     "Submit a confirmed spoke-chain transaction to the SODAX intent relay so it can be delivered to the destination chain. The tx must already be finalized on the source chain. Re-submitting the same tx is a no-op. For split-tx chains (Solana, Bitcoin) supply the optional `data` argument.",
     {
@@ -224,7 +231,9 @@ export function registerSolverRelayTools(server: McpServer): void {
   );
 
   // ── Relay: get transaction packets ──────────────────────────────────
-  server.tool(
+  registerAppTool(
+    server,
+    "relay",
     "sodax_relay_get_transaction_packets",
     "List every cross-chain packet emitted by a given source transaction. Use this to track relay status — a packet is complete when status='executed' and dst_tx_hash is populated.",
     {
@@ -277,7 +286,9 @@ export function registerSolverRelayTools(server: McpServer): void {
   );
 
   // ── Relay: get packet ───────────────────────────────────────────────
-  server.tool(
+  registerAppTool(
+    server,
+    "relay",
     "sodax_relay_get_packet",
     "Fetch a single relay packet by its connection serial number (conn_sn). Returns the packet data on success or a `{success:false, message}` shape if the packet isn't found.",
     {


### PR DESCRIPTION
## Promote `development` → `master`

Promotes the merged **#66** — landing-page refresh with a single-source-of-truth tool registry, live network/tool counts, sodax.com footer, dark hero — plus the review-driven correctness/perf/a11y hardening that landed during review.

**Scope:** 1 squash-merge (`a03cd04`), 14 files, +771 / −281.

### What's included
- **Tool registry** as the single source of truth for `/health`, `/api`, and landing-page counts — no more hand-maintained numbers.
- **Live network count** (ICON filtered) with a `0`/`null` → evergreen-floor normalization (no `0+` surface).
- **Non-blocking `/health` + `/api`** — served from the warmed GitBook cache so they never stall on a 30s fetch when GitBook is down.
- **Accessibility** — footer logo and external-link icons marked decorative.
- **Server-side landing-page rendering** — SEO surfaces (meta/OG/JSON-LD) always reflect what the server exposes.

Full review history (12 findings, 11 addressed / 1 declined) is on #66. Staging validation is in the comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
